### PR TITLE
Closes issue #9 - Apply patch suggested by @xmw

### DIFF
--- a/mod_xinerama/Makefile
+++ b/mod_xinerama/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/build/system-inc.mk
 
 ######################################
 
-INCLUDES += $(LIBTU_INCLUDES) $(LIBEXTL_INCLUDES) $(X11_INCLUDES) -I$(TOPDIR)
-CFLAGS += $(XOPEN_SOURCE) $(C99_SOURCE)
+INCLUDES += $(LIBTU_INCLUDES) $(LIBEXTL_INCLUDES) $(X11_INCLUDES) -I$(TOPDIR) $(shell $(PKG_CONFIG) --cflags-only-I xinerama)
+CFLAGS += $(XOPEN_SOURCE) $(C99_SOURCE) $(shell $(PKG_CONFIG) --cflags-only-other xinerama)
 DOCS=LICENSE README
 
 SOURCES=mod_xinerama.c
 
 MAKE_EXPORTS=mod_xinerama
-LIBS = -L/usr/lib/x86_64-linux-gnu $(X11_LIBS) -lXinerama
+LIBS = $(X11_LIBS) $(shell $(PKG_CONFIG) --libs xinerama)
 MODULE=mod_xinerama
 MODULE_STUB=mod_xinerama.lua
 
@@ -44,7 +44,7 @@ tarball: $(SOURCES) $(ETC) $(DOCS) $(MODULE_STUB) Makefile
 
 .PHONY: test
 test: $(SOURCES)
-	lua test_xinerama.lua
+	$(LUA) test_xinerama.lua
 
 ######################################
 
@@ -57,4 +57,4 @@ mod_xinerama.o: exports.h
 ################ ls_xinerama utility ###############
 
 ls_xinerama: ls_xinerama.c
-	$(CC) ls_xinerama.c -o ls_xinerama -Wl,--as-needed -lX11 -lXinerama
+	$(CC) $(CFLAGS) ls_xinerama.c -o ls_xinerama $(LDFLAGS) $(LIBS)

--- a/mod_xrandr/Makefile
+++ b/mod_xrandr/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/build/system-inc.mk
 
 ######################################
 
-INCLUDES += $(LIBTU_INCLUDES) $(LIBEXTL_INCLUDES) $(X11_INCLUDES) -I$(TOPDIR)
-CFLAGS += $(XOPEN_SOURCE) $(C99_SOURCE)
+INCLUDES += $(LIBTU_INCLUDES) $(LIBEXTL_INCLUDES) $(X11_INCLUDES) -I$(TOPDIR) $(shell pkg-config --cflags-only-I xrandr)
+CFLAGS += $(XOPEN_SOURCE) $(C99_SOURCE) $(shell $(PKG_CONFIG) --cflags-only-other xrandr)
 
 SOURCES=mod_xrandr.c
 
 MAKE_EXPORTS=mod_xrandr
-LIBS = $(X11_LIBS) -lXrandr
+LIBS = $(X11_LIBS) $(shell $(PKG_CONFIG) --libs xrandr)
 MODULE=mod_xrandr
 MODULE_STUB=mod_xrandr.lua
 ETC=cfg_xrandr.lua
@@ -45,7 +45,7 @@ tarball: $(SOURCES) $(ETC) $(DOCS) Makefile
 
 .PHONY: test
 test: $(SOURCES)
-	for i in test_xrandr*.lua ; do echo 'Testing' $$i ; lua $$i ; done
+	for i in test_xrandr*.lua ; do echo 'Testing' $$i ; $(LUA) $$i ; done
 
 ######################################
 

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -84,8 +84,8 @@ X11_PREFIX ?= /usr/X11R6
 # SunOS/Solaris
 #X11_PREFIX ?= /usr/openwin
 
-X11_LIBS=-L$(X11_PREFIX)/lib -lX11 -lXext
-X11_INCLUDES=-I$(X11_PREFIX)/include
+X11_LIBS=$(shell $(PKG_CONFIG) --libs x11 xext)
+X11_INCLUDES=$(shell $(PKG_CONFIG) --cflags-only-I x11 xext)
 
 # XFree86 libraries up to 4.3.0 have a bug that can cause a segfault.
 # The following setting  should  work around that situation.


### PR DESCRIPTION
The patch changes declaratiosn to use pkg-config instead of hardcoded
flags as suggested by @xmw
See: 
- https://github.com/raboof/notion/issues/9
- https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/x11-wm/notion/files/notion-3_p2015061300-pkg-config.patch?view=markup
