### PR TITLE
Add sizepolicy support for menus

### DIFF
--- a/mod_menu/grabmenu.c
+++ b/mod_menu/grabmenu.c
@@ -93,7 +93,8 @@ WMenu *mod_menu_do_grabmenu(WMPlex *mplex, ExtlFn handler, ExtlTab tab,
                MPLEX_ATTACH_LEVEL|
                MPLEX_ATTACH_UNNUMBERED|
                MPLEX_ATTACH_SIZEPOLICY);
-    par.szplcy=SIZEPOLICY_FULL_BOUNDS;
+    if (FALSE==extl_table_gets_sizepolicy(param, "sizepolicy", &par.szplcy))
+        par.szplcy=SIZEPOLICY_FULL_BOUNDS;
     par.level=STACKING_LEVEL_MODAL1+2;
 
     menu=(WMenu*)mplex_do_attach_new(mplex, &par,

--- a/mod_menu/mkmenu.c
+++ b/mod_menu/mkmenu.c
@@ -50,7 +50,8 @@ WMenu *mod_menu_do_menu(WMPlex *mplex, ExtlFn handler, ExtlTab tab,
                MPLEX_ATTACH_LEVEL|
                MPLEX_ATTACH_UNNUMBERED|
                MPLEX_ATTACH_SIZEPOLICY);
-    par.szplcy=SIZEPOLICY_FULL_BOUNDS;
+    if (FALSE==extl_table_gets_sizepolicy(param, "sizepolicy", &par.szplcy))
+        par.szplcy=SIZEPOLICY_FULL_BOUNDS;
     par.level=STACKING_LEVEL_MODAL1+2;
     
     return (WMenu*)mplex_do_attach_new(mplex, &par,

--- a/mod_menu/mod_menu.lua
+++ b/mod_menu/mod_menu.lua
@@ -52,6 +52,7 @@ end
 -- \var{param}. The initial entry can be specified as the field
 -- \var{initial} as an integer starting from 1. Menus can be made
 -- to use a bigger style by setting the field \var{big} to \code{true}.
+-- The position can be set using the field \var{sizepolicy}.
 function mod_menu.menu(mplex, sub, menu_or_name, param) 
    local function menu_stdmenu(m, s, menu)
         return ioncore.unsqueeze(mod_menu.do_menu(m, s, menu, param))


### PR DESCRIPTION
This allows you to position menus according to sizepolicy. Which lets you use center for instance, which is often nicer than the lower-left corner. I've been using the patch for a long time without any issues.