### PR TITLE
Add focuslist menu for workspaces

### DIFF
--- a/etc/cfg_notioncore.lua
+++ b/etc/cfg_notioncore.lua
@@ -188,6 +188,9 @@ defbindings("WMPlex.toplevel", {
         -- (_chld) is a group 'bottom' and detaches the whole group in that
         -- case.
         kpress("D", "ioncore.detach(_chld, 'toggle')", "_chld:non-nil"),
+
+        bdoc("Menu for recently used workspaces."),
+        kpress("G", "mod_menu.menu(_, _sub, 'workspacefocuslist')"),
     }),
 })
 

--- a/ioncore/ioncore_menudb.lua
+++ b/ioncore/ioncore_menudb.lua
@@ -262,6 +262,33 @@ function menus.workspacefocuslist()
     return entries
 end
 
+--DOC
+-- Go to and return to a previously active workspace (if any).
+--
+-- Note that this function is asynchronous; the region will not
+-- actually have received the focus when this function returns.
+function ioncore.goto_previous_workspace()
+    local ws
+    local focused_ws=ws_or_fullscreen_of(ioncore.current())
+
+    local function iter(reg)
+        ws=ws_or_fullscreen_of(reg)
+
+        if ws and not (ws==focused_ws) then
+            return false
+        end
+        return true
+    end
+
+    -- Add workspaces which have had focus
+    ioncore.focushistory_i(iter)
+
+    if ws then
+        ws:goto_focus()
+    end
+    return ws
+end
+
 -- }}}
 
 


### PR DESCRIPTION
### Description and motivation

This adds a recently used workspace menu, `'workspacefocuslist'`, which works 
like `'focuslist'` but for workspaces.

Moving around with this menu is really nice, especially when using several
screens, where moving a workspace to another screen makes workspace ordering
hard to follow. It has become my primary way to move to any workspace, together
with `goto_previous_workspace`, making relative workspace movement somewhat
obsolete.

### Functionality 

Workspaces which haven't been visited are added to the end of the menu, with an
entry for creating a new workspace at the very end. Visited fullscreen windows
are regarded as workspaces and scratchpads are ignored. Scratchpads are detected
using `mod_sp.is_scratchpad`, which isn't perfect since it only checks if the
frame or workspace has a certain name. Another option is checking if the
workspace is `unnumbered`, but I'm uncertain if that will have unintended
consequences.

### Binding

The `META..K G` binding wasn't taken, which is a natural placement, mirroring
`META..G`, it's bound using a regular menu so it's easy to do a quick search.
While it's nice having both the `focuslist` menu and `query_gotoclient` for
client windows the focuslist for workspaces fills both roles due to the lesser
number of workspaces used. 

### Misc

In addition there's a function `ioncore.goto_previous_workspace` which mirrors
`ioncore.goto_previous`. Its placement in `menudb.lua` isn't quite ideal. The
alternative would be code duplication, since it relies on the same helper
function as the menu, which doesn't fit well as a global function. Using
`workspacefocuslist` through `grabmenu` makes this function somewhat obsolete,
so that's an option. Open to suggestions on an alternative.