### PR TITLE
Don't call region_do_warp_alt callback when the cursor is in the frame

### DIFF
--- a/ioncore/focus.c
+++ b/ioncore/focus.c
@@ -452,8 +452,9 @@ bool ioncore_should_focus_parent_when_refusing_focus(WRegion* reg){
 }
 
 void region_finalise_focusing(WRegion* reg, Window win, bool warp, Time time, int set_input) { 
-    if(warp)
+    if(warp && !region_is_cursor_inside(reg)){
         region_do_warp(reg);
+    }
     
     if(REGION_IS_ACTIVE(reg) && ioncore_await_focus()==NULL)
         return;
@@ -478,6 +479,30 @@ static WRegion *find_warp_to_reg(WRegion *reg)
     return find_warp_to_reg(region_manager_or_parent(reg));
 }
 
+bool region_is_cursor_inside(WRegion *reg)
+{
+    int x, y, w, h, px=0, py=0;
+    WRootWin *root;
+
+    reg=find_warp_to_reg(reg);
+
+    if(reg==NULL)
+        return FALSE;
+
+    D(fprintf(stderr, "region_is_cursor_inside %p %s\n", reg, OBJ_TYPESTR(reg)));
+
+    root=region_rootwin_of(reg);
+
+    region_rootpos(reg, &x, &y);
+    w=REGION_GEOM(reg).w;
+    h=REGION_GEOM(reg).h;
+
+    if(xwindow_pointer_pos(WROOTWIN_ROOT(root), &px, &py)){
+        if(px>=x && py>=y && px<x+w && py<y+h)
+            return TRUE;
+    }
+    return FALSE;
+}
 
 bool region_do_warp_default(WRegion *reg)
 {
@@ -494,13 +519,6 @@ bool region_do_warp_default(WRegion *reg)
     root=region_rootwin_of(reg);
     
     region_rootpos(reg, &x, &y);
-    w=REGION_GEOM(reg).w;
-    h=REGION_GEOM(reg).h;
-
-    if(xwindow_pointer_pos(WROOTWIN_ROOT(root), &px, &py)){
-        if(px>=x && py>=y && px<x+w && py<y+h)
-            return TRUE;
-    }
     
     rootwin_warp_pointer(root, x+5, y+5);
         

--- a/ioncore/focus.c
+++ b/ioncore/focus.c
@@ -23,6 +23,7 @@
 
 
 static void region_focuslist_awaiting_insertion_trigger(void);
+static WRegion *find_warp_to_reg(WRegion *reg);
 
 /*{{{ Hooks. */
 
@@ -470,7 +471,6 @@ void region_finalise_focusing(WRegion* reg, Window win, bool warp, Time time, in
         XSetInputFocus(ioncore_g.dpy, reg->parent->win, RevertToParent, time);
    }
 }
-
 
 
 static WRegion *find_warp_to_reg(WRegion *reg)

--- a/ioncore/focus.c
+++ b/ioncore/focus.c
@@ -452,10 +452,13 @@ bool ioncore_should_focus_parent_when_refusing_focus(WRegion* reg){
 }
 
 void region_finalise_focusing(WRegion* reg, Window win, bool warp, Time time, int set_input) { 
-    if(warp && !region_is_cursor_inside(reg)){
-        region_do_warp(reg);
+    if(warp) {
+        WRegion* reg_warp=find_warp_to_reg(reg);
+        if(reg_warp!=NULL && region_is_cursor_inside(reg_warp)){
+            region_do_warp(reg_warp);
+        }
     }
-    
+
     if(REGION_IS_ACTIVE(reg) && ioncore_await_focus()==NULL)
         return;
     
@@ -484,11 +487,6 @@ bool region_is_cursor_inside(WRegion *reg)
     int x, y, w, h, px=0, py=0;
     WRootWin *root;
 
-    reg=find_warp_to_reg(reg);
-
-    if(reg==NULL)
-        return FALSE;
-
     D(fprintf(stderr, "region_is_cursor_inside %p %s\n", reg, OBJ_TYPESTR(reg)));
 
     root=region_rootwin_of(reg);
@@ -506,14 +504,9 @@ bool region_is_cursor_inside(WRegion *reg)
 
 bool region_do_warp_default(WRegion *reg)
 {
-    int x, y, w, h, px=0, py=0;
+    int x, y;
     WRootWin *root;
-    
-    reg=find_warp_to_reg(reg);
-    
-    if(reg==NULL)
-        return FALSE;
-    
+
     D(fprintf(stderr, "region_do_warp %p %s\n", reg, OBJ_TYPESTR(reg)));
     
     root=region_rootwin_of(reg);

--- a/ioncore/focus.h
+++ b/ioncore/focus.h
@@ -28,6 +28,7 @@ extern void region_finalise_focusing(WRegion* reg, Window win, bool warp, Time t
 DYNFUN void region_do_set_focus(WRegion *reg, bool warp);
 extern void region_do_warp(WRegion *reg);
 extern bool region_do_warp_default(WRegion *reg);
+extern bool region_is_cursor_inside(WRegion *reg);
 
 /* Awaiting focus state */
 extern void region_set_await_focus(WRegion *reg);


### PR DESCRIPTION
Running the cursor warping callback when the cursor is in the frame is annoying and runs when:

- Clicking on tabs
- Cycling between frames (Alt-Tab)

