### PR TITLE
Add options for warp cursor placement

### DIFF
--- a/etc/cfg_notion.lua
+++ b/etc/cfg_notion.lua
@@ -42,6 +42,19 @@ ioncore.set{
     -- changing focus. Enabled by default.
     --warp=true,
 
+    -- Margin to use when warping the cursor (in pixels),
+    -- to inset from the edge of the frame.
+    --warp_margin=5,
+
+    -- Placement to use when positioning the cursor in the frame
+    -- (as a factor from 0-1).
+    -- Where an x,y value:
+    -- * (0.0, 0.0) for top-left.
+    -- * (1.0, 1.0) for bottom-right.
+    -- * (0.5, 0.5) for the center of the frame.
+    --warp_factor_x=0.0,
+    --warp_factor_y=0.0,
+
     -- Switch frames to display newly mapped windows.
     --switchto=true,
 

--- a/ioncore/conf.c
+++ b/ioncore/conf.c
@@ -58,6 +58,10 @@ static ExtlFn get_layout_fn;
  *                        object in question at every step (true). \\
  *  \var{warp} &          (boolean) Should focusing operations move the 
  *                        pointer to the object to be focused? \\
+ *  \var{warp_margin} &   (integer) Border offset in pixels to apply
+ *                        to the cursor when warping. \\
+ *  \var{warp_factor} &   (double[2]) X & Y factor to offset the cursor.
+ *                        between 0 and 1, where 0.5 is the center. \\
  *  \var{switchto} &      (boolean) Should a managing \type{WMPlex} switch
  *                        to a newly mapped client window? \\
  *  \var{screen_notify} & (boolean) Should notification tooltips be displayed
@@ -130,6 +134,9 @@ void ioncore_set(ExtlTab tab)
     
     extl_table_gets_b(tab, "opaque_resize", &(ioncore_g.opaque_resize));
     extl_table_gets_b(tab, "warp", &(ioncore_g.warp_enabled));
+    extl_table_gets_i(tab, "warp_margin", &(ioncore_g.warp_margin));
+    extl_table_gets_d(tab, "warp_factor_x", &(ioncore_g.warp_factor[0]));
+    extl_table_gets_d(tab, "warp_factor_y", &(ioncore_g.warp_factor[1]));
     extl_table_gets_b(tab, "switchto", &(ioncore_g.switchto_new));
     extl_table_gets_b(tab, "screen_notify", &(ioncore_g.screen_notify));
     extl_table_gets_b(tab, "framed_transients", &(ioncore_g.framed_transients));

--- a/ioncore/focus.c
+++ b/ioncore/focus.c
@@ -455,7 +455,7 @@ bool ioncore_should_focus_parent_when_refusing_focus(WRegion* reg){
 void region_finalise_focusing(WRegion* reg, Window win, bool warp, Time time, int set_input) { 
     if(warp) {
         WRegion* reg_warp=find_warp_to_reg(reg);
-        if(reg_warp!=NULL && region_is_cursor_inside(reg_warp)){
+        if(reg_warp!=NULL && !region_is_cursor_inside(reg_warp)){
             region_do_warp(reg_warp);
         }
     }
@@ -513,7 +513,22 @@ bool region_do_warp_default(WRegion *reg)
     
     region_rootpos(reg, &x, &y);
     
-    rootwin_warp_pointer(root, x+5, y+5);
+    x+=REGION_GEOM(reg).w*ioncore_g.warp_factor[0];
+    y+=REGION_GEOM(reg).h*ioncore_g.warp_factor[1];
+
+    if(ioncore_g.warp_factor[0] < 0.5) {
+        x+=ioncore_g.warp_margin;
+    }else if(ioncore_g.warp_factor[0] > 0.5) {
+        x-=ioncore_g.warp_margin;
+    }
+
+    if(ioncore_g.warp_factor[1] < 0.5) {
+        y+=ioncore_g.warp_margin;
+    }else if(ioncore_g.warp_factor[1] > 0.5) {
+        y-=ioncore_g.warp_margin;
+    }
+
+    rootwin_warp_pointer(root, x, y);
         
     return TRUE;
 }

--- a/ioncore/global.h
+++ b/ioncore/global.h
@@ -101,6 +101,8 @@ DECLSTRUCT(WGlobal){
     Time dblclick_delay;
     int opaque_resize;
     bool warp_enabled;
+    int warp_margin;
+    double warp_factor[2];
     bool switchto_new;
     bool screen_notify;
     int frame_default_index;

--- a/ioncore/ioncore.c
+++ b/ioncore/ioncore.c
@@ -362,6 +362,9 @@ static bool init_global()
     ioncore_g.usertime_diff_new=CF_USERTIME_DIFF_NEW;
     ioncore_g.opaque_resize=0;
     ioncore_g.warp_enabled=TRUE;
+    ioncore_g.warp_margin=5;
+    ioncore_g.warp_factor[0]=0.0;
+    ioncore_g.warp_factor[1]=0.0;
     ioncore_g.switchto_new=TRUE;
     ioncore_g.no_mousefocus=FALSE;
     ioncore_g.unsqueeze_enabled=TRUE;


### PR DESCRIPTION
Add options to offset the cursor when warping, while this is possible using callbacks, typically users will want to select a corner or the center of the frame.

There are no changes to the default behavior, now users can easily center the cursor by changing some options.

From the embedded config:

```
    -- Margin to use when warping the cursor (in pixels),
    -- to inset from the edge of the frame.
    --warp_margin=5,

    -- Placement to use when positioning the cursor in the frame
    -- (as a factor from 0-1).
    -- Where an x,y value:
    -- * (0.0, 0.0) for top-left.
    -- * (1.0, 1.0) for bottom-right.
    -- * (0.5, 0.5) for the center of the frame.
    --warp_factor_x=0.0,
    --warp_factor_y=0.0,
```

---- 
This also corrects mistake in previous PR, `region_is_cursor_inside` check was flipped.
