### PR TITLE
Fix buffer overrun reading WM_STATE

### DIFF
--- a/ioncore/clientwin.c
+++ b/ioncore/clientwin.c
@@ -43,7 +43,7 @@
 #include "group.h"
 
 
-static void set_clientwin_state(WClientWin *cwin, int state);
+static void set_clientwin_state(WClientWin *cwin, unsigned int state);
 static bool send_clientmsg(Window win, Atom a, Time stmp);
 
 
@@ -843,7 +843,7 @@ void clientwin_rqclose(WClientWin *cwin, bool UNUSED(relocate_ignored))
 /*{{{ State (hide/show) */
 
 
-static void set_clientwin_state(WClientWin *cwin, int state)
+static void set_clientwin_state(WClientWin *cwin, unsigned int state)
 {
     if(cwin->state!=state){
         cwin->state=state;

--- a/ioncore/property.c
+++ b/ioncore/property.c
@@ -129,16 +129,19 @@ void xwindow_set_integer_property(Window win, Atom a, int value)
 /* WM_STATE
  */
 
-bool xwindow_get_state_property(Window win, int *state)
+bool xwindow_get_state_property(Window win, unsigned int *state)
 {
-    CARD32 *p=NULL;
+    struct{
+        CARD32 state;
+        XID    icon;
+    }*p;
     
     if(xwindow_get_property(win, ioncore_g.atom_wm_state, 
                             ioncore_g.atom_wm_state, 
                             2L, FALSE, (uchar**)&p)<=0)
         return FALSE;
     
-    *state=*p;
+    *state=p->state;
     
     XFree((void*)p);
     
@@ -146,16 +149,19 @@ bool xwindow_get_state_property(Window win, int *state)
 }
 
 
-void xwindow_set_state_property(Window win, int state)
+void xwindow_set_state_property(Window win, unsigned int state)
 {
-    CARD32 data[2];
-    
-    data[0]=state;
-    data[1]=None;
+    struct{
+        CARD32 state;
+        XID    icon;
+    }data;
+
+    data.state = state;
+    data.icon = None;
     
     XChangeProperty(ioncore_g.dpy, win,
                     ioncore_g.atom_wm_state, ioncore_g.atom_wm_state,
-                    32, PropModeReplace, (uchar*)data, 2);
+                    32, PropModeReplace, (uchar*)&data, 2);
 }
 
 

--- a/ioncore/property.h
+++ b/ioncore/property.h
@@ -20,8 +20,8 @@ extern char *xwindow_get_string_property(Window win, Atom a, int *nret);
 extern void xwindow_set_string_property(Window win, Atom a, const char *value);
 extern bool xwindow_get_integer_property(Window win, Atom a, int *vret);
 extern void xwindow_set_integer_property(Window win, Atom a, int value);
-extern bool xwindow_get_state_property(Window win, int *state);
-extern void xwindow_set_state_property(Window win, int state);
+extern bool xwindow_get_state_property(Window win, unsigned int *state);
+extern void xwindow_set_state_property(Window win, unsigned int  state);
 extern char **xwindow_get_text_property(Window win, Atom a, int *nret);
 
 /** 


### PR DESCRIPTION
While the first value is defined to be CARD32,
the actual array is Atom/long (openbox uses ulong, Blender uses Atom
both resolve to long.

Note that this isn't mentioned in the docs, but most uses I could find
use either long or Atom.

See details:
```
==6703== Syscall param writev(vector[...]) points to uninitialised byte(s)
==6703==    at 0x5DB2B60: __writev_nocancel (in /usr/lib/libc-2.24.so)
==6703==    by 0x607CBAC: ??? (in /usr/lib/libxcb.so.1.1.0)
==6703==    by 0x607CFAC: ??? (in /usr/lib/libxcb.so.1.1.0)
==6703==    by 0x607D02C: xcb_writev (in /usr/lib/libxcb.so.1.1.0)
==6703==    by 0x4E78F4D: _XSend (in /usr/lib/libX11.so.6.3.0)
==6703==    by 0x4E79441: _XReply (in /usr/lib/libX11.so.6.3.0)
==6703==    by 0x4E5F7AD: XGetWindowProperty (in /usr/lib/libX11.so.6.3.0)
==6703==    by 0x41C0A9: xwindow_get_property_ (property.c:30)
==6703==    by 0x41C187: xwindow_get_property (property.c:59)
==6703==    by 0x41C2A9: xwindow_get_integer_property (property.c:106)
==6703==    by 0x423D93: clientwin_load (clientwin.c:1438)
==6703==    by 0x42D391: create_region_load (saveload.c:106)
==6703==    by 0x4270A8: wrap_load (attach.c:133)
==6703==    by 0x426E08: doit_new (attach.c:33)
==6703==    by 0x42716F: doit_load (attach.c:163)
==6703==    by 0x4271C2: region_attach_load_helper (attach.c:174)
==6703==    by 0x440E3A: group_do_load (group.c:1354)
==6703==    by 0x44206D: groupcw_load (group-cw.c:301)
==6703==    by 0x42D391: create_region_load (saveload.c:106)
==6703==    by 0x4270A8: wrap_load (attach.c:133)
==6703==    by 0x426E08: doit_new (attach.c:33)
==6703==    by 0x42716F: doit_load (attach.c:163)
==6703==    by 0x4271C2: region_attach_load_helper (attach.c:174)
==6703==    by 0x434D59: mplex_load_contents (mplex.c:2164)
==6703==    by 0x42F330: frame_do_load (frame.c:911)
==6703==    by 0x42F3D4: frame_load (frame.c:931)
==6703==    by 0x42D391: create_region_load (saveload.c:106)
==6703==    by 0x4270A8: wrap_load (attach.c:133)
==6703==    by 0x426E08: doit_new (attach.c:33)
==6703==    by 0x42716F: doit_load (attach.c:163)
==6703==    by 0x427265: region_attach_helper (attach.c:187)
==6703==    by 0x7916940: load_splitregion (tiling.c:1496)
==6703==    by 0x7916D67: tiling_load_node_default (tiling.c:1609)
==6703==    by 0x7916E7B: tiling_load_node (tiling.c:1628)
==6703==    by 0x7916C17: load_splitsplit (tiling.c:1566)
==6703==    by 0x7916D9D: tiling_load_node_default (tiling.c:1611)
==6703==    by 0x7916E7B: tiling_load_node (tiling.c:1628)
==6703==    by 0x7916B8C: load_splitsplit (tiling.c:1552)
==6703==    by 0x7916D9D: tiling_load_node_default (tiling.c:1611)
==6703==    by 0x7916E7B: tiling_load_node (tiling.c:1628)
==6703==    by 0x7916F1E: tiling_load (tiling.c:1652)
==6703==    by 0x42D391: create_region_load (saveload.c:106)
==6703==    by 0x4270A8: wrap_load (attach.c:133)
==6703==    by 0x426E08: doit_new (attach.c:33)
==6703==    by 0x42716F: doit_load (attach.c:163)
==6703==    by 0x4271C2: region_attach_load_helper (attach.c:174)
==6703==    by 0x440E3A: group_do_load (group.c:1354)
==6703==    by 0x44354B: groupws_load (group-ws.c:350)
==6703==    by 0x42D391: create_region_load (saveload.c:106)
==6703==    by 0x4270A8: wrap_load (attach.c:133)
==6703==  Address 0x690ccb4 is 52 bytes inside a block of size 16,384 alloc'd
==6703==    at 0x4C2CA40: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==6703==    by 0x4E69395: XOpenDisplay (in /usr/lib/libX11.so.6.3.0)
==6703==    by 0x41FBEA: ioncore_init_x (ioncore.c:506)
==6703==    by 0x4200DC: ioncore_startup (ioncore.c:627)
==6703==    by 0x41568F: main (notion.c:239)
==6703==  Uninitialised value was created by a stack allocation
==6703==    at 0x41C3A7: xwindow_set_state_property (property.c:150)
==6703== 
```