### PR TITLE
Free strings on exit

### DIFF
--- a/ioncore/clientwin.c
+++ b/ioncore/clientwin.c
@@ -797,7 +797,7 @@ void clientwin_destroyed(WClientWin *cwin)
 
 static bool send_clientmsg(Window win, Atom a, Time stmp)
 {
-    XClientMessageEvent ev;
+    XClientMessageEvent ev = {0};
     
     ev.type=ClientMessage;
     ev.window=win;

--- a/ioncore/ioncore.c
+++ b/ioncore/ioncore.c
@@ -675,8 +675,10 @@ void ioncore_deinit()
 
     ioncore_deinit_bindmaps();
 
+    stringstore_deinit();
+
     mainloop_unregister_input_fd(ioncore_g.conn);
-    
+
     dpy=ioncore_g.dpy;
     ioncore_g.dpy=NULL;
     

--- a/libtu/stringstore.c
+++ b/libtu/stringstore.c
@@ -142,3 +142,12 @@ void stringstore_ref(StringId id)
         node->v.ival++;
 }
 
+void stringstore_deinit(void) {
+    if(stringstore!=NULL){
+        Rb_node node;
+        while ((node=rb_first(stringstore))!=rb_nil(stringstore)) {
+            node->v.ival = 1;
+            stringstore_free((StringId)node);
+        }
+    }
+}

--- a/libtu/stringstore.h
+++ b/libtu/stringstore.h
@@ -21,5 +21,6 @@ extern StringId stringstore_find_n(const char *str, uint l);
 extern StringId stringstore_alloc_n(const char *str, uint l);
 extern void stringstore_free(StringId id);
 extern void stringstore_ref(StringId id);
+extern void stringstore_free_all(void);
 
 #endif /* LIBTU_STRINGSTORE_H */


### PR DESCRIPTION
Currently stringstore makes it hard to track real leaks,
this frees them on exit.

While it might be nicer to visit each string and free it, not sure its practical.
Though it could be better to postpone this patch, or run it - but print unfreed strings as errors in debug mode.
Then ensure all strings are freed.