### PR TITLE
WIP: Tab icons

### DIFF
--- a/de/draw.c
+++ b/de/draw.c
@@ -551,8 +551,9 @@ void debrush_draw_iconbox(DEBrush *brush,
     debrush_do_draw_box(brush, geom, cg, needfill);
 
     if(elem->icon){
-        /* TODO: Probably not the best idea to lie about the real window dimensions */
-        cairo_surface_t *xsurf=cairo_xlib_surface_create(ioncore_g.dpy, brush->win, DefaultVisual(ioncore_g.dpy, 0), geom->w, geom->h);
+        /* TODO: Probably not the best idea to lie about the real window dimensions (but under reporting seems to work) */
+        /* TODO: How expensive is it to create a new surface per icon? Could easily reuse it */
+        cairo_surface_t *xsurf=cairo_xlib_surface_create(ioncore_g.dpy, brush->win, DefaultVisual(ioncore_g.dpy, 0), geom->x+geom->w, geom->h);
         cairo_t *cr = cairo_create(xsurf);
         cairo_set_source_surface(cr, elem->icon, geom->x+bdw.left+1, geom->y+bdw.top);
         /* cairo_rectangle(cr, geom->x, geom->y, 16, 16); */

--- a/de/draw.c
+++ b/de/draw.c
@@ -510,6 +510,36 @@ void debrush_draw_textbox(DEBrush *brush, const WRectangle *geom,
     }
 }
 
+void debrush_draw_iconbox(DEBrush *brush,
+                          const WRectangle *geom,
+                          const GrTextElem *elem,
+                          DEColourGroup *cg,
+                          bool needfill,
+                          const GrStyleSpec *a1,
+                          const GrStyleSpec *a2,
+                          int index)
+{
+    WRectangle text_geom=*geom;
+    if(elem->icon){
+        /* Leave space for icon */
+        /* text_geom.x+=16+2; */
+    }
+    debrush_do_draw_textbox(brush, &text_geom, elem->text, cg, needfill,
+                            a1, &elem->attr, index);
+
+    if(elem->icon){
+        /* TODO: Probably not the best idea to lie about the real window dimensions */
+        cairo_surface_t *xsurf=cairo_xlib_surface_create(ioncore_g.dpy, brush->win, DefaultVisual(ioncore_g.dpy, 0), 700, 400);
+        cairo_t *cr = cairo_create(xsurf);
+        cairo_set_source_surface(cr, elem->icon, geom->x+2, geom->y+2);
+        /* cairo_rectangle(cr, geom->x, geom->y, 16, 16); */
+        /* cairo_fill(cr); */
+        cairo_paint(cr);
+        cairo_surface_destroy(xsurf);
+        cairo_destroy(cr);
+    }
+}
+
 
 void debrush_draw_textboxes(DEBrush *brush, const WRectangle *geom,
                             int n, const GrTextElem *elem,
@@ -530,8 +560,10 @@ void debrush_draw_textboxes(DEBrush *brush, const WRectangle *geom,
         cg=debrush_get_colour_group2(brush, common_attrib, &elem[i].attr);
 
         if(cg!=NULL){
-            debrush_do_draw_textbox(brush, &g, elem[i].text, cg, needfill,
-                                    common_attrib, &elem[i].attr, i);
+            /* debrush_do_draw_textbox(brush, &g, elem[i].text, cg, needfill, */
+            /*                         common_attrib, &elem[i].attr, i); */
+            debrush_draw_iconbox(brush, &g, &elem[i], cg, needfill,
+                                 common_attrib, &elem[i].attr, i);
         }
 
         if(i==n-1)

--- a/de/draw.c
+++ b/de/draw.c
@@ -13,6 +13,7 @@
 #include <ioncore/common.h>
 #include <ioncore/gr.h>
 #include <ioncore/gr-util.h>
+#include <libtu/minmax.h>
 #include "brush.h"
 #include "font.h"
 #include "private.h"
@@ -445,6 +446,35 @@ void debrush_do_draw_box(DEBrush *brush, const WRectangle *geom,
     debrush_do_draw_border(brush, *geom, cg);
 }
 
+static uint get_tx(DEBrush *brush,
+                   const WRectangle *geom,
+                   const char *text,
+                   const GrBorderWidths *bdw,
+                   uint extra
+                   )
+{
+    uint len=0;
+    uint tx, tw=extra;
+
+    if(text)
+        len=strlen(text);
+
+    if(brush->d->textalign!=DEALIGN_LEFT){
+        if(text)
+            tw+=grbrush_get_text_width((GrBrush*)brush, text, len);
+
+        if(brush->d->textalign==DEALIGN_CENTER)
+            tx=geom->x+bdw->left+(geom->w-bdw->left-bdw->right-tw)/2;
+        else
+            tx=geom->x+geom->w-bdw->right-tw;
+    }else{
+        tx=geom->x+bdw->left;
+    }
+
+    return tx;
+}
+
+
 /* Draws the text within a box denoted by goem, aligned according to the
    brush */
 static void debrush_draw_text(DEBrush *brush,
@@ -456,7 +486,8 @@ static void debrush_draw_text(DEBrush *brush,
                               )
 {
     uint len;
-    uint tx, ty, tw;
+    uint tx, ty;
+
     do{ /*...while(0)*/
         if(text==NULL)
             break;
@@ -466,20 +497,12 @@ static void debrush_draw_text(DEBrush *brush,
         if(len==0)
             break;
 
-        if(brush->d->textalign!=DEALIGN_LEFT){
-            tw=grbrush_get_text_width((GrBrush*)brush, text, len);
-
-            if(brush->d->textalign==DEALIGN_CENTER)
-                tx=geom->x+bdw->left+(geom->w-bdw->left-bdw->right-tw)/2;
-            else
-                tx=geom->x+geom->w-bdw->right-tw;
-        }else{
-            tx=geom->x+bdw->left;
-        }
+        tx=get_tx(brush, geom, text, bdw, 0);
 
         ty=get_ty(geom, bdw, fnte);
 
         debrush_do_draw_string(brush, tx, ty, text, len, FALSE, cg);
+
     }while(0);
 }
 
@@ -523,6 +546,7 @@ void debrush_draw_textbox(DEBrush *brush, const WRectangle *geom,
 }
 
 void debrush_draw_iconbox(DEBrush *brush,
+                          cairo_t *cr,
                           const WRectangle *geom,
                           const GrTextElem *elem,
                           DEColourGroup *cg,
@@ -538,39 +562,40 @@ void debrush_draw_iconbox(DEBrush *brush,
     grbrush_get_border_widths(&(brush->grbrush), &bdw);
     grbrush_get_font_extents(&(brush->grbrush), &fnte);
 
-    WRectangle text_geom=*geom;
-    if(elem->icon){
-        /* Leave space for icon */
-        text_geom.x+=16;
-        text_geom.w-=16;
-    }
-
     if(brush->extras_fn!=NULL)
         brush->extras_fn(brush, geom, cg, &bdw, &fnte, a1, a2, TRUE, index);
 
     debrush_do_draw_box(brush, geom, cg, needfill);
 
+    uint tx, ty, len;
+    uint icon_width=elem->icon?16+3:0; /* including small right padding */
+    const char *text=elem->text;
+
+    bool icon_align_left=TRUE;
+    debrush_get_extra(brush, "icon_align_left", 'b', &icon_align_left);
+
+    len=text?strlen(text):0;
+
+    tx=get_tx(brush, geom, text, &bdw, icon_align_left?0:icon_width);
+    ty=get_ty(geom, &bdw, &fnte);
+
     if(elem->icon){
-        /* TODO: Probably not the best idea to lie about the real window dimensions (but under reporting seems to work) */
-        /* TODO: How expensive is it to create a new surface per icon? Could easily reuse it */
-        cairo_surface_t *xsurf=cairo_xlib_surface_create(ioncore_g.dpy, brush->win, DefaultVisual(ioncore_g.dpy, 0), geom->x+geom->w, geom->h);
-        cairo_t *cr = cairo_create(xsurf);
-        cairo_set_source_surface(cr, elem->icon, geom->x+bdw.left+1, geom->y+bdw.top);
+        uint icon_x=icon_align_left ? geom->x+bdw.left : tx;
+        cairo_set_source_surface(cr, elem->icon, icon_x, geom->y+bdw.top);
+        /* cairo_set_source_surface(cr, elem->icon, geom->x+bdw.left+1, geom->y+bdw.top); */
         /* cairo_rectangle(cr, geom->x, geom->y, 16, 16); */
         /* cairo_fill(cr); */
         cairo_paint(cr);
-        cairo_surface_destroy(xsurf);
-        cairo_destroy(cr);
+        if(icon_align_left)
+            tx=MAXOF(icon_x+icon_width, tx);
+        else
+            tx+=icon_width;
     }
 
-    debrush_draw_text(brush, &text_geom, elem->text, cg, &bdw, &fnte);
+    debrush_do_draw_string(brush, tx, ty, text, len, FALSE, cg);
 
     if(brush->extras_fn!=NULL)
         brush->extras_fn(brush, geom, cg, &bdw, &fnte, a1, a2, FALSE, index);
-    
-    /* debrush_do_draw_textbox(brush, &text_geom, elem->text, cg, needfill, */
-    /*                         a1, &elem->attr, index); */
-
 }
 
 
@@ -584,12 +609,20 @@ void debrush_draw_textboxes(DEBrush *brush, const WRectangle *geom,
     GrBorderWidths bdw;
     int i;
     bool show_icon=FALSE;
+    cairo_surface_t *xsurf=NULL;
+    cairo_t *cr=NULL;
+
+    debrush_get_extra(brush, "show_icon", 'b', &show_icon);
 
     common_attrib=debrush_get_current_attr(brush);
 
     grbrush_get_border_widths(&(brush->grbrush), &bdw);
 
-    grbrush_get_extra(brush, "show_icon", 'b', &show_icon);
+    if(show_icon){
+        /* Seems like under-reporting the window dimensions to cairo is ok */
+        xsurf=cairo_xlib_surface_create(ioncore_g.dpy, brush->win, DefaultVisual(ioncore_g.dpy, 0), geom->x+geom->w, geom->h);
+        cr=cairo_create(xsurf);
+    }
 
     for(i=0; ; i++){
         g.w=bdw.left+elem[i].iw+bdw.right;
@@ -597,7 +630,7 @@ void debrush_draw_textboxes(DEBrush *brush, const WRectangle *geom,
 
         if(cg!=NULL){
             if(show_icon){
-                debrush_draw_iconbox(brush, &g, &elem[i], cg, needfill,
+                debrush_draw_iconbox(brush, cr, &g, &elem[i], cg, needfill,
                                      common_attrib, &elem[i].attr, i);
             }else{
                 debrush_do_draw_textbox(brush, &g, elem[i].text, cg, needfill,
@@ -615,6 +648,11 @@ void debrush_draw_textboxes(DEBrush *brush, const WRectangle *geom,
         }
         g.x+=bdw.spacing;
     }
+
+    if(xsurf)
+        cairo_surface_destroy(xsurf);
+    if(cr)
+        cairo_destroy(cr);
 }
 
 

--- a/de/draw.c
+++ b/de/draw.c
@@ -445,29 +445,18 @@ void debrush_do_draw_box(DEBrush *brush, const WRectangle *geom,
     debrush_do_draw_border(brush, *geom, cg);
 }
 
-
-static void debrush_do_draw_textbox(DEBrush *brush,
-                                    const WRectangle *geom,
-                                    const char *text,
-                                    DEColourGroup *cg,
-                                    bool needfill,
-                                    const GrStyleSpec *a1,
-                                    const GrStyleSpec *a2,
-                                    int index)
+/* Draws the text within a box denoted by goem, aligned according to the
+   brush */
+static void debrush_draw_text(DEBrush *brush,
+                              const WRectangle *geom,
+                              const char *text,
+                              DEColourGroup *cg,
+                              const GrBorderWidths *bdw,
+                              const GrFontExtents *fnte
+                              )
 {
     uint len;
-    GrBorderWidths bdw;
-    GrFontExtents fnte;
     uint tx, ty, tw;
-
-    grbrush_get_border_widths(&(brush->grbrush), &bdw);
-    grbrush_get_font_extents(&(brush->grbrush), &fnte);
-
-    if(brush->extras_fn!=NULL)
-        brush->extras_fn(brush, geom, cg, &bdw, &fnte, a1, a2, TRUE, index);
-
-    debrush_do_draw_box(brush, geom, cg, needfill);
-
     do{ /*...while(0)*/
         if(text==NULL)
             break;
@@ -481,17 +470,40 @@ static void debrush_do_draw_textbox(DEBrush *brush,
             tw=grbrush_get_text_width((GrBrush*)brush, text, len);
 
             if(brush->d->textalign==DEALIGN_CENTER)
-                tx=geom->x+bdw.left+(geom->w-bdw.left-bdw.right-tw)/2;
+                tx=geom->x+bdw->left+(geom->w-bdw->left-bdw->right-tw)/2;
             else
-                tx=geom->x+geom->w-bdw.right-tw;
+                tx=geom->x+geom->w-bdw->right-tw;
         }else{
-            tx=geom->x+bdw.left;
+            tx=geom->x+bdw->left;
         }
 
-        ty=get_ty(geom, &bdw, &fnte);
+        ty=get_ty(geom, bdw, fnte);
 
         debrush_do_draw_string(brush, tx, ty, text, len, FALSE, cg);
     }while(0);
+}
+
+static void debrush_do_draw_textbox(DEBrush *brush,
+                                    const WRectangle *geom,
+                                    const char *text,
+                                    DEColourGroup *cg,
+                                    bool needfill,
+                                    const GrStyleSpec *a1,
+                                    const GrStyleSpec *a2,
+                                    int index)
+{
+    GrBorderWidths bdw;
+    GrFontExtents fnte;
+
+    grbrush_get_border_widths(&(brush->grbrush), &bdw);
+    grbrush_get_font_extents(&(brush->grbrush), &fnte);
+
+    if(brush->extras_fn!=NULL)
+        brush->extras_fn(brush, geom, cg, &bdw, &fnte, a1, a2, TRUE, index);
+
+    debrush_do_draw_box(brush, geom, cg, needfill);
+
+    debrush_draw_text(brush, geom, text, cg, &bdw, &fnte);
 
     if(brush->extras_fn!=NULL)
         brush->extras_fn(brush, geom, cg, &bdw, &fnte, a1, a2, FALSE, index);
@@ -519,25 +531,45 @@ void debrush_draw_iconbox(DEBrush *brush,
                           const GrStyleSpec *a2,
                           int index)
 {
+
+    GrBorderWidths bdw;
+    GrFontExtents fnte;
+
+    grbrush_get_border_widths(&(brush->grbrush), &bdw);
+    grbrush_get_font_extents(&(brush->grbrush), &fnte);
+
     WRectangle text_geom=*geom;
     if(elem->icon){
         /* Leave space for icon */
-        /* text_geom.x+=16+2; */
+        text_geom.x+=16;
+        text_geom.w-=16;
     }
-    debrush_do_draw_textbox(brush, &text_geom, elem->text, cg, needfill,
-                            a1, &elem->attr, index);
+
+    if(brush->extras_fn!=NULL)
+        brush->extras_fn(brush, geom, cg, &bdw, &fnte, a1, a2, TRUE, index);
+
+    debrush_do_draw_box(brush, geom, cg, needfill);
 
     if(elem->icon){
         /* TODO: Probably not the best idea to lie about the real window dimensions */
-        cairo_surface_t *xsurf=cairo_xlib_surface_create(ioncore_g.dpy, brush->win, DefaultVisual(ioncore_g.dpy, 0), 700, 400);
+        cairo_surface_t *xsurf=cairo_xlib_surface_create(ioncore_g.dpy, brush->win, DefaultVisual(ioncore_g.dpy, 0), geom->w, geom->h);
         cairo_t *cr = cairo_create(xsurf);
-        cairo_set_source_surface(cr, elem->icon, geom->x+2, geom->y+2);
+        cairo_set_source_surface(cr, elem->icon, geom->x+bdw.left+1, geom->y+bdw.top);
         /* cairo_rectangle(cr, geom->x, geom->y, 16, 16); */
         /* cairo_fill(cr); */
         cairo_paint(cr);
         cairo_surface_destroy(xsurf);
         cairo_destroy(cr);
     }
+
+    debrush_draw_text(brush, &text_geom, elem->text, cg, &bdw, &fnte);
+
+    if(brush->extras_fn!=NULL)
+        brush->extras_fn(brush, geom, cg, &bdw, &fnte, a1, a2, FALSE, index);
+    
+    /* debrush_do_draw_textbox(brush, &text_geom, elem->text, cg, needfill, */
+    /*                         a1, &elem->attr, index); */
+
 }
 
 
@@ -550,20 +582,26 @@ void debrush_draw_textboxes(DEBrush *brush, const WRectangle *geom,
     DEColourGroup *cg;
     GrBorderWidths bdw;
     int i;
+    bool show_icon=FALSE;
 
     common_attrib=debrush_get_current_attr(brush);
 
     grbrush_get_border_widths(&(brush->grbrush), &bdw);
+
+    grbrush_get_extra(brush, "show_icon", 'b', &show_icon);
 
     for(i=0; ; i++){
         g.w=bdw.left+elem[i].iw+bdw.right;
         cg=debrush_get_colour_group2(brush, common_attrib, &elem[i].attr);
 
         if(cg!=NULL){
-            /* debrush_do_draw_textbox(brush, &g, elem[i].text, cg, needfill, */
-            /*                         common_attrib, &elem[i].attr, i); */
-            debrush_draw_iconbox(brush, &g, &elem[i], cg, needfill,
-                                 common_attrib, &elem[i].attr, i);
+            if(show_icon){
+                debrush_draw_iconbox(brush, &g, &elem[i], cg, needfill,
+                                     common_attrib, &elem[i].attr, i);
+            }else{
+                debrush_do_draw_textbox(brush, &g, elem[i].text, cg, needfill,
+                                        common_attrib, &elem[i].attr, i);
+            }
         }
 
         if(i==n-1)

--- a/etc/lookcommon_clean.lua
+++ b/etc/lookcommon_clean.lua
@@ -42,6 +42,7 @@ de.defstyle("actnotify", {
 })
 
 de.defstyle("tab", {
+    show_icon = true,
     de.substyle("*-*-*-unselected-activity", {
         shadow_colour = "#c04040",
         highlight_colour = "#c04040",

--- a/ioncore/clientwin.c
+++ b/ioncore/clientwin.c
@@ -240,6 +240,11 @@ static cairo_surface_t *scale_cairo_image_surface(cairo_surface_t *source, int t
 
 static void clientwin_get_icon(WClientWin *cwin)
 {
+    if(cwin->icon){
+        cairo_surface_destroy(cwin->icon);
+        cwin->icon=NULL;
+    }
+
     cairo_surface_t *icon = netwm_window_icon(cwin, 16);
     if(icon!=NULL && cairo_image_surface_get_width(icon)!=16){
         /* TODO: Are all icons square? */
@@ -250,6 +255,12 @@ static void clientwin_get_icon(WClientWin *cwin)
     }
 
     cwin->icon=icon;
+}
+
+void clientwin_refresh_icon(WClientWin *cwin)
+{
+    clientwin_get_icon(cwin);
+    region_notify_change(cwin, ioncore_g.notifies.icon);
 }
 
 void clientwin_get_set_name(WClientWin *cwin)

--- a/ioncore/clientwin.c
+++ b/ioncore/clientwin.c
@@ -221,6 +221,37 @@ void clientwin_get_input_wm_hint(WClientWin *cwin)
     }
 }
 
+
+static cairo_surface_t *scale_cairo_image_surface(cairo_surface_t *source, int target_w, int target_h)
+{
+    int source_w=cairo_image_surface_get_width(source);
+    int source_h=cairo_image_surface_get_height(source);
+
+    cairo_surface_t *result=cairo_surface_create_similar(source, CAIRO_CONTENT_COLOR_ALPHA, target_w, target_h);
+    cairo_t *cr=cairo_create(result);
+    cairo_scale(cr, ((double)target_w)/source_w, ((double)target_h)/source_h);
+    /* https://www.cairographics.org/manual/cairo-cairo-pattern-t.html#cairo-pattern-set-filter
+     * to set interpolation method */
+    cairo_set_source_surface(cr, source, 0, 0);
+    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+    cairo_paint(cr);
+    return result;
+}
+
+static void clientwin_get_icon(WClientWin *cwin)
+{
+    cairo_surface_t *icon = netwm_window_icon(cwin, 16);
+    if(icon!=NULL && cairo_image_surface_get_width(icon)!=16){
+        /* TODO: Are all icons square? */
+        /* rescale */
+        cairo_surface_t *scaled=scale_cairo_image_surface(icon, 16, 16);
+        cairo_surface_destroy(icon);
+        icon = scaled;
+    }
+
+    cwin->icon=icon;
+}
+
 void clientwin_get_set_name(WClientWin *cwin)
 {
     char **list=NULL;
@@ -313,6 +344,7 @@ static bool clientwin_init(WClientWin *cwin, WWindow *par, Window win,
     WFitParams fp;
 
     cwin->flags=0;
+    cwin->icon=NULL;
     cwin->win=win;
     cwin->state=WithdrawnState;
 
@@ -358,6 +390,7 @@ static bool clientwin_init(WClientWin *cwin, WWindow *par, Window win,
     clientwin_get_winprops(cwin);
     clientwin_get_size_hints(cwin);
     clientwin_get_input_wm_hint(cwin);
+    clientwin_get_icon(cwin);
 
     netwm_update_allowed_actions(cwin);
 
@@ -711,6 +744,11 @@ static bool reparent_root(WClientWin *cwin)
 
 void clientwin_deinit(WClientWin *cwin)
 {
+    if(cwin->icon){
+        cairo_surface_destroy(cwin->icon);
+        cwin->icon=NULL;
+    }
+
     if(cwin->win!=None){
         region_pointer_focus_hack(&cwin->region);
 
@@ -1110,6 +1148,10 @@ static int clientwin_orientation(WClientWin *cwin)
                : REGION_ORIENTATION_NONE));
 }
 
+static cairo_surface_t *clientwin_icon(WClientWin *cwin)
+{
+    return cwin->icon;
+}
 
 /*}}}*/
 
@@ -1524,6 +1566,10 @@ static DynFunTab clientwin_dynfuntab[]={
 
     {(DynFun*)region_get_configuration,
      (DynFun*)clientwin_get_configuration},
+
+
+    {(DynFun*)region_icon,
+     (DynFun*)clientwin_icon},
 
     END_DYNFUNTAB
 };

--- a/ioncore/clientwin.h
+++ b/ioncore/clientwin.h
@@ -53,6 +53,8 @@ DECLCLASS(WClientWin){
     int event_mask;
     Window win;
 
+    cairo_surface_t *icon;
+
     int orig_bw;
 
     Colormap cmap;

--- a/ioncore/clientwin.h
+++ b/ioncore/clientwin.h
@@ -85,6 +85,7 @@ extern void clientwin_rqclose(WClientWin *cwin, bool relocate_ignored);
 extern void clientwin_tfor_changed(WClientWin *cwin);
 
 extern void clientwin_get_set_name(WClientWin *cwin);
+extern void clientwin_refresh_icon(WClientWin *cwin);
 
 extern void clientwin_handle_configure_request(WClientWin *cwin,
                                                XConfigureRequestEvent *ev);

--- a/ioncore/common.h
+++ b/ioncore/common.h
@@ -11,6 +11,8 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <cairo/cairo.h>
+#include <cairo/cairo-xlib.h>
 
 #include <libtu/types.h>
 #include <libtu/output.h>

--- a/ioncore/frame-draw.c
+++ b/ioncore/frame-draw.c
@@ -276,7 +276,7 @@ void frame_recalc_bar(WFrame *frame, bool complete)
             if(frame->show_icon){
                 const cairo_surface_t *icon=region_icon(sub);
                 if(icon) {
-                    icon_w=cairo_image_surface_get_width(icon);
+                    icon_w=cairo_image_surface_get_width(icon)+3;
                 }
             }
 

--- a/ioncore/frame-draw.c
+++ b/ioncore/frame-draw.c
@@ -75,6 +75,12 @@ void frame_update_attr(WFrame *frame, int i, WRegion *reg)
 
     spec=&frame->titles[i].attr;
 
+    cairo_surface_t *tab_icon=frame->titles[i].icon;
+    if(tab_icon){
+        cairo_surface_destroy(tab_icon);
+        tab_icon=NULL;
+    }
+
     frame->titles[i].icon = reg ? region_icon(reg) : NULL;
 
     selected=(reg==FRAME_CURRENT(frame));

--- a/ioncore/frame-draw.c
+++ b/ioncore/frame-draw.c
@@ -75,6 +75,8 @@ void frame_update_attr(WFrame *frame, int i, WRegion *reg)
 
     spec=&frame->titles[i].attr;
 
+    frame->titles[i].icon = reg ? region_icon(reg) : NULL;
+
     selected=(reg==FRAME_CURRENT(frame));
     tagged=(reg!=NULL && reg->flags&REGION_TAGGED);
     dragged=(i==frame->tab_dragged_idx);
@@ -270,6 +272,7 @@ void frame_recalc_bar(WFrame *frame, bool complete)
         free_title(frame, i);
         textw=frame->titles[i].iw;
         if(textw>0){
+            /* TODO: subtract possible icon width */
             title=region_make_label(sub, textw, frame->bar_brush);
             frame->titles[i].text=title;
         }

--- a/ioncore/frame-draw.c
+++ b/ioncore/frame-draw.c
@@ -272,8 +272,15 @@ void frame_recalc_bar(WFrame *frame, bool complete)
         free_title(frame, i);
         textw=frame->titles[i].iw;
         if(textw>0){
-            /* TODO: subtract possible icon width */
-            title=region_make_label(sub, textw, frame->bar_brush);
+            int icon_w=0;
+            if(frame->show_icon){
+                const cairo_surface_t *icon=region_icon(sub);
+                if(icon) {
+                    icon_w=cairo_image_surface_get_width(icon);
+                }
+            }
+
+            title=region_make_label(sub, textw-icon_w, frame->bar_brush);
             frame->titles[i].text=title;
         }
         i++;
@@ -353,6 +360,8 @@ void frame_brushes_updated(WFrame *frame)
         free(s);
     }
 
+    grbrush_get_extra(frame->bar_brush, "show_icon", 'b', &frame->show_icon);
+
     frame->barmode=barmode;
 
     if(barmode==FRAME_BAR_NONE || frame->bar_brush==NULL){
@@ -364,7 +373,9 @@ void frame_brushes_updated(WFrame *frame)
         grbrush_get_border_widths(frame->bar_brush, &bdw);
         grbrush_get_font_extents(frame->bar_brush, &fnte);
 
-        frame->bar_h=bdw.top+bdw.bottom+fnte.max_height;
+        int inner_h=frame->show_icon ? MAXOF(fnte.max_height,16) : fnte.max_height;
+
+        frame->bar_h=bdw.top+bdw.bottom+inner_h;
     }
 
     /* tabs and bar width calculation stuff */

--- a/ioncore/frame.c
+++ b/ioncore/frame.c
@@ -99,6 +99,7 @@ bool frame_init(WFrame *frame, WWindow *parent, const WFitParams *fp,
     frame->tr_mode=GR_TRANSPARENCY_DEFAULT;
     frame->brush=NULL;
     frame->bar_brush=NULL;
+    frame->show_icon=FALSE;
     frame->mode=mode;
     frame_tabs_width_recalc_init(frame);
 

--- a/ioncore/frame.c
+++ b/ioncore/frame.c
@@ -325,12 +325,16 @@ static void frame_update_attrs(WFrame *frame)
 static void frame_free_titles(WFrame *frame)
 {
     int i;
-
+    GrTextElem title;
+    
     if(frame->titles!=NULL){
         for(i=0; i<frame->titles_n; i++){
-            if(frame->titles[i].text)
-                free(frame->titles[i].text);
-            gr_stylespec_unalloc(&frame->titles[i].attr);
+            title=frame->titles[i];
+            if(title.icon)
+                cairo_surface_destroy(title.icon);
+            if(title.text)
+                free(title.text);
+            gr_stylespec_unalloc(&title.attr);
         }
         free(frame->titles);
         frame->titles=NULL;
@@ -342,6 +346,7 @@ static void frame_free_titles(WFrame *frame)
 static void do_init_title(WFrame *frame, int i, WRegion *sub)
 {
     frame->titles[i].text=NULL;
+    frame->titles[i].icon=NULL;
 
     gr_stylespec_init(&frame->titles[i].attr);
 

--- a/ioncore/frame.c
+++ b/ioncore/frame.c
@@ -775,9 +775,10 @@ void frame_managed_notify(WFrame *frame, WRegion *UNUSED(sub), WRegionNotify how
        how==ioncore_g.notifies.name ||
        how==ioncore_g.notifies.activity ||
        how==ioncore_g.notifies.sub_activity ||
-       how==ioncore_g.notifies.tag){
+       how==ioncore_g.notifies.tag ||
+       how==ioncore_g.notifies.icon){
 
-        complete=how==ioncore_g.notifies.name;
+        complete=how==ioncore_g.notifies.name||how==ioncore_g.notifies.icon;
 
         frame_update_attrs(frame);
         frame_recalc_bar(frame, complete);

--- a/ioncore/frame.h
+++ b/ioncore/frame.h
@@ -76,6 +76,7 @@ DECLCLASS(WFrame){
     /* Bar stuff */
     WFrameBarMode barmode;
     int bar_w, bar_h;
+    bool show_icon;
     /* Parameters to calculate tab sizes. */
     TabCalcParams tabs_params;
 };

--- a/ioncore/global.h
+++ b/ioncore/global.h
@@ -130,6 +130,7 @@ DECLSTRUCT(WGlobal){
                  activity,
                  sub_activity,
                  name,
+                 icon,
                  unset_manager,
                  set_manager,
                  tag,

--- a/ioncore/gr.h
+++ b/ioncore/gr.h
@@ -63,6 +63,7 @@ typedef struct{
     char *text;
     int iw;
     GrStyleSpec attr;
+    cairo_surface_t *icon;
 } GrTextElem;
 
 typedef enum{

--- a/ioncore/group-cw.c
+++ b/ioncore/group-cw.c
@@ -200,6 +200,16 @@ const char *groupcw_displayname(WGroupCW *cwg)
     return name;
 }
 
+cairo_surface_t *groupcw_icon(WGroupCW *cwg)
+{
+    cairo_surface_t *icon=NULL;
+
+    if(cwg->grp.bottom!=NULL && cwg->grp.bottom->reg!=NULL)
+        icon=region_icon(cwg->grp.bottom->reg);
+
+    return icon;
+}
+
 
 void groupcw_managed_notify(WGroupCW *cwg, WRegion *reg, WRegionNotify how)
 {
@@ -346,6 +356,9 @@ static DynFunTab groupcw_dynfuntab[]={
 
     {(DynFun*)region_displayname,
      (DynFun*)groupcw_displayname},
+
+    {(DynFun*)region_icon,
+     (DynFun*)groupcw_icon},
 
     {region_managed_notify,
      groupcw_managed_notify},

--- a/ioncore/group-cw.c
+++ b/ioncore/group-cw.c
@@ -213,8 +213,9 @@ cairo_surface_t *groupcw_icon(WGroupCW *cwg)
 
 void groupcw_managed_notify(WGroupCW *cwg, WRegion *reg, WRegionNotify how)
 {
-    if(group_bottom(&cwg->grp)==reg && how==ioncore_g.notifies.name){
-        /* Title has changed */
+    if(group_bottom(&cwg->grp)==reg &&
+       (how==ioncore_g.notifies.name||how==ioncore_g.notifies.icon)){
+        /* Title or icon has changed */
         region_notify_change((WRegion*)cwg, how);
     }
 

--- a/ioncore/ioncore.c
+++ b/ioncore/ioncore.c
@@ -394,6 +394,7 @@ static bool init_global()
     INITSTR(activity);
     INITSTR(sub_activity);
     INITSTR(name);
+    INITSTR(icon);
     INITSTR(unset_manager);
     INITSTR(set_manager);
     INITSTR(unset_return);

--- a/ioncore/netwm.c
+++ b/ioncore/netwm.c
@@ -374,7 +374,7 @@ cairo_surface_t *draw_surface_from_data(int width, int height, ulong *data)
  * 
  * Adapted from awesome-wm
  */
-cairo_surface_t * netwm_window_icon(WClientWin *cwin, uint preferred_size)
+cairo_surface_t *netwm_window_icon(WClientWin *cwin, uint preferred_size)
 {
     cairo_surface_t *ret=NULL;
     ulong *data=NULL, *end, *found_data = 0;

--- a/ioncore/netwm.c
+++ b/ioncore/netwm.c
@@ -42,7 +42,7 @@ static Atom atom_net_wm_allowed_actions=0;
 static Atom atom_net_wm_moveresize=0;
 static Atom atom_net_wm_icon=0;
 
-#define N_NETWM 9
+#define N_NETWM 10
 
 static Atom atom_net_supported=0;
 
@@ -87,6 +87,7 @@ void netwm_init_rootwin(WRootWin *rw)
     atoms[6]=atom_net_active_window;
     atoms[7]=atom_net_wm_allowed_actions;
     atoms[8]=atom_net_wm_moveresize;
+    atoms[9]=atom_net_wm_icon;
 
     XChangeProperty(ioncore_g.dpy, WROOTWIN_ROOT(rw),
                     atom_net_supporting_wm_check, XA_WINDOW,
@@ -308,11 +309,15 @@ void netwm_handle_client_message(const XClientMessageEvent *ev)
 
 bool netwm_handle_property(WClientWin *cwin, const XPropertyEvent *ev)
 {
-    if(ev->atom!=atom_net_wm_name)
-        return FALSE;
+    if(ev->atom==atom_net_wm_name){
+        clientwin_get_set_name(cwin);
+        return TRUE;
+    } else if(ev->atom==atom_net_wm_icon){
+        clientwin_refresh_icon(cwin);
+        return TRUE;
+    }
 
-    clientwin_get_set_name(cwin);
-    return TRUE;
+    return FALSE;
 }
 
 

--- a/ioncore/netwm.h
+++ b/ioncore/netwm.h
@@ -30,6 +30,8 @@ extern char **netwm_get_name(WClientWin *cwin);
 extern void netwm_handle_client_message(const XClientMessageEvent *ev);
 extern bool netwm_handle_property(WClientWin *cwin, const XPropertyEvent *ev);
 
+extern cairo_surface_t *netwm_window_icon(WClientWin *cwin, uint preferred_size);
+
 extern void netwm_check_manage_user_time(WClientWin *cwin, WManageParams *param);
 
 extern void ioncore_screens_updated(WRootWin *rw);

--- a/ioncore/region.c
+++ b/ioncore/region.c
@@ -198,6 +198,25 @@ void region_do_set_focus(WRegion *reg, bool warp)
     CALL_DYN(region_do_set_focus, reg, (reg, warp));
 }
 
+/*
+ * Returns a icon representing this region. The surface should be an image
+ * surface and the callee is responsible for calling 'cairo_surface_destroy'
+ * when done with the icon. (reference counting)
+ *
+ * NULL if no icon.
+ */
+cairo_surface_t *region_icon(WRegion *reg)
+{
+    cairo_surface_t *icon=NULL;
+    CALL_DYN_RET(icon, cairo_surface_t*, region_icon, reg, (reg));
+
+    if(icon!=NULL){
+        cairo_surface_reference(icon);
+    }
+    return icon;
+}
+
+
 
 /*{{{ Manager region dynfuns */
 
@@ -271,6 +290,11 @@ void region_updategr_default(WRegion *reg)
     FOR_ALL_CHILDREN(reg, sub){
         region_updategr(sub);
     }
+}
+
+cairo_surface_t *region_icon_default(WRegion *reg)
+{
+    return NULL;
 }
 
 
@@ -1058,6 +1082,9 @@ static DynFunTab region_dynfuntab[]={
 
     {(DynFun*)region_displayname,
      (DynFun*)region_name},
+
+    {(DynFun*)region_icon,
+     (DynFun*)region_icon_default},
 
     {region_stacking,
      region_stacking_default},

--- a/ioncore/region.h
+++ b/ioncore/region.h
@@ -149,6 +149,8 @@ DYNFUN void region_stacking(WRegion *reg, Window *bottomret, Window *topret);
 
 DYNFUN bool region_handle_drop(WRegion *reg, int x, int y, WRegion *dropped);
 
+DYNFUN cairo_surface_t *region_icon(WRegion *reg);
+
 extern bool region_rqorder(WRegion *reg, WRegionOrder order);
 
 extern bool region_prepare_focus(WRegion *reg, int flags,

--- a/libextl/luaextl.c
+++ b/libextl/luaextl.c
@@ -634,6 +634,7 @@ static bool extl_stack_get(lua_State *st, int pos, char type,
                            void *valret)
 {
     double d=0;
+    bool b=FALSE;
     const char *str;
 
     if(wasdeadobject!=NULL)
@@ -665,6 +666,22 @@ static bool extl_stack_get(lua_State *st, int pos, char type,
         }else{
             if(valret)
                 *((double*)valret)=d;
+        }
+        return TRUE;
+    case LUA_TBOOLEAN:
+        if(type!='b' && type!='a')
+            return FALSE;
+
+        b=lua_toboolean(st, pos);
+
+        if(type=='b'){
+            if(valret)
+                *((bool*)valret)=b;
+        }else if(type=='a'){
+            if(valret){
+                ((ExtlAny*)valret)->type='b';
+                ((ExtlAny*)valret)->value.b=b;
+            }
         }
         return TRUE;
 

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -103,6 +103,17 @@ DEFINES += -DCF_XFREE86_TEXTPROP_BUG_WORKAROUND
 
 
 ##
+## Cairo
+##
+
+CAIRO_LIBS=$(shell $(PKG_CONFIG) --libs cairo)
+CAIRO_INCLUDES=$(shell $(PKG_CONFIG) --cflags cairo)
+
+# Be a bit lazy and include cairo all places x11 is used
+X11_LIBS += $(CAIRO_LIBS)
+X11_INCLUDES += $(CAIRO_INCLUDES)
+
+##
 ## Localisation
 ##
 


### PR DESCRIPTION
Work in progress adding icons to tabs. (ie. render `_NET_WM_ICON`)

Status: Works, but the code need some cleaning, and I haven't decided on all design choices yet.

Toggled through a style attribute `show_icon`. It's enabled for the clean looks in the branch. If you use a different look (or keep the look files in ~/.notion) add  `show_icon = true` to `defstyle("tab", ...` or `defstyle("tab-frame", ...`

`icon_align_left=false|true` controls the alignment (whether the icon follows the text of is always left aligned)

I put this PR out there a bit early to get some indication on whether the feature is wanted at all and maybe some feedback/input. If there's little interest I might just maintain the branch in a less polished state.

cairo is a dependency.

1. Is there strong feelings about needing a build flag? (a runtime option to will obviously be included)
2. Is it worth adding `icon_path` to winprops?
3. The icon size is hadcoded to 16x16 px atm. Is anyone interested in larger/smaller sizes?

(ref: #38)

![2017-02-22-182019_992x676_scrot](https://cloud.githubusercontent.com/assets/72201/23223579/b04b759a-f92b-11e6-9de1-43d662f4e433.png)

