### PR TITLE
notionflux: distinct exit status on lua error

### DIFF
--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -184,6 +184,7 @@ int main(int argc, char *argv[])
     int use_stdin=1;
     char res;
     int n;
+    int exit_status=0;
 
     if(argc>1){
         if(argc!=3 || strcmp(argv[1], "-e")!=0)
@@ -235,15 +236,18 @@ int main(int argc, char *argv[])
         if(n==0)
             break;
 
-        if(res=='S')
+        if(res=='S'){
             mywrite(1, buf, n);
-        else /* res=='E' */
+        }
+        else{ /* res=='E' */
             mywrite(2, buf, n);
+            exit_status=2;
+        }
 
         if(n<MAX_DATA)
             break;
     }
 
-    return 0;
+    return exit_status;
 }
 


### PR DESCRIPTION
At least three useful groups of notionflux results
1. Technical failure (notion not running, to much data to send, etc.)
2. Error when loading or running lua code (syntax error, NPE, etc.)
3. Success

It's possible to differentiate between these today since the output for case 2 is written to stderr, but it's not very convenient.

This change could potentially break scripts using notionflux, but I find it quite unlikely.

Motivation for this change is to improve https://github.com/olejorgenb/notion-wm (yeah, I should really rename the repo)