### PR TITLE
Contrib: Glue code to use rofi as a menu replacement/alternative

### DIFF
--- a/contrib/scripts/notion_rofi.sh
+++ b/contrib/scripts/notion_rofi.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env zsh
+#
+# Example:
+# rofi -show notion -modi "notion:'./notion_rofi.sh focuslist'" -scroll-method 1
+
+function escape {
+    sed "s/'/\\'/g"
+}
+
+MENU_NAME=$1
+
+if [[ -z $2 ]]; then
+    # No argument -> generate menu entries
+
+    notionflux -e "return rofi.menu_list('$MENU_NAME')"  \
+    | sed -e 's/\\"/"/g' -e 's/^"//' -e 's/\\$//g' -e '$d'
+else
+    # Entry selected
+
+    ENTRY=$(echo $2 | escape)
+    notionflux -e "rofi.menu_action('$MENU_NAME', '$ENTRY')" > /dev/null
+fi

--- a/contrib/scripts/notion_rofi.sh
+++ b/contrib/scripts/notion_rofi.sh
@@ -4,13 +4,16 @@
 # rofi -show notion -modi "notion:'./notion_rofi.sh focuslist'" -scroll-method 1
 
 function escape {
-    sed "s/'/\\'/g"
+    sed "s/'/\\\'/g"
 }
 
 MENU_NAME=$1
 
 if [[ -z $2 ]]; then
     # No argument -> generate menu entries
+
+    # Unfortunately there's no good way getting pure stdout from notionflux?
+    # Massage the format of the return string into a usable list.
 
     notionflux -e "return rofi.menu_list('$MENU_NAME')"  \
     | sed -e 's/\\"/"/g' -e 's/^"//' -e 's/\\$//g' -e '$d'

--- a/contrib/scripts/rofi.lua
+++ b/contrib/scripts/rofi.lua
@@ -1,0 +1,32 @@
+rofi = {}
+
+rofi.active_menu_entries = {}
+
+function rofi.menu_list(menu_name)
+  local entry_lines = ""
+
+  local entries = ioncore.getmenu(menu_name)()
+
+  rofi.active_menu_entries[menu_name] = {}
+
+  for i,entry in ipairs(entries) do
+    entry_lines = entry_lines .. entry.name .. "\n"
+    rofi.active_menu_entries[menu_name][entry.name] = entry.func
+  end
+
+  return entry_lines
+end
+
+function rofi.menu_action(menu_name, entry_name)
+  rofi.active_menu_entries[menu_name][entry_name]()
+end
+
+
+-- To replace all menus with rofi set mod_menu.menu = rofi.menu
+-- notion_rofi.sh must be moved to ~/.notion/ first
+function rofi.menu(mplex, sub, menu, unused_parms)
+    local helper = notioncore.get_paths()["userdir"].."/notion_rofi.sh"
+    local rofispec = string.format("%s:%s %s", menu, helper, menu)
+
+    ioncore.exec(string.format("rofi -show %s -modi '%s'", menu, rofispec))
+end


### PR DESCRIPTION
[Rofi](https://github.com/DaveDavenport/rofi)

Adds `rofi.menu` - a `mod_menu.menu` compatible (mostly at least) replacement/alternative. 

An advantage over notion's menus is that it support fuzzier matching. (each word in the query is matched independently against the menu content making it order-independent for instance. The menu is also interactively filtered down.

Rofi support a built-in mode for switching windows which works with notion (when net_client_list is loaded), but the windows isn't listed in MRU order, and the rofi's built in workspace menu doesn't work IIRC.

Atm only regular menus is supported, but I don't think it would be very hard to support context menus too.

The mechanism used for passing data is a bit messy (suggestions welcome) but it works. 

Coauthored with @hedning 

![2017-04-11-063312_1366x768_scrot](https://cloud.githubusercontent.com/assets/72201/24893030/fbc54396-1e80-11e7-9e99-cc93e51653af.png)
