### PR TITLE
Support for coexisting xft and bitmap fonts

### DIFF
--- a/de/colour.h
+++ b/de/colour.h
@@ -26,6 +26,11 @@ typedef XftColor DEColour;
 typedef unsigned long DEColour;
 #endif /* HAVE_X11_XFT */
 
+#ifdef HAVE_X11_XFT
+#  define PIXEL(x) (x).pixel
+#else /* HAVE_X11_XFT */
+#  define PIXEL(x) x
+#endif /* HAVE_X11_XFT */
 
 DECLSTRUCT(DEColourGroup){
     GrStyleSpec spec;

--- a/de/draw.c
+++ b/de/draw.c
@@ -19,14 +19,6 @@
 
 #include <X11/extensions/shape.h>
 
-
-#ifdef HAVE_X11_XFT
-#  define PIXEL(x) (x).pixel
-#else /* HAVE_X11_XFT */
-#  define PIXEL(x) x
-#endif /* HAVE_X11_XFT */
-
-
 /*{{{ Colour group lookup */
 
 

--- a/de/font.h
+++ b/de/font.h
@@ -28,8 +28,10 @@ INTRSTRUCT(DEFont);
 DECLSTRUCT(DEFont){
     char *pattern;
     int refcount;
+#ifdef HAVE_X11_BMF
     XFontSet fontset;
     XFontStruct *fontstruct;
+#endif /* HAVE_X11_BMF */
 #ifdef HAVE_X11_XFT /* HAVE_X11_XFT */
     XftFont *font;
 #endif /* HAVE_X11_XFT */

--- a/de/style.c
+++ b/de/style.c
@@ -70,12 +70,12 @@ void destyle_create_tab_gcs(DEStyle *style)
     /*gcv.function=GXclear;*/
     gcv.stipple=stipple_pixmap;
     gcvmask=GCFillStyle|GCStipple/*|GCFunction*/;
-#ifndef HAVE_X11_XFT
+#ifdef HAVE_X11_BMF
     if(style->font!=NULL && style->font->fontstruct!=NULL){
         gcv.font=style->font->fontstruct->fid;
         gcvmask|=GCFont;
     }
-#endif /* HAVE_X11_XFT */
+#endif /* HAVE_X11_BMF */
 
     style->stipple_gc=XCreateGC(dpy, root, gcvmask, &gcv);
     XCopyGC(dpy, style->normal_gc,

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -112,6 +112,9 @@ ifeq ($(USE_XFT),1)
     X11_INCLUDES += `pkg-config xft --cflags`
     X11_LIBS += `pkg-config xft --libs`
     DEFINES += -DHAVE_X11_XFT
+    DEFINES += -DHAVE_X11_BMF
+else
+    DEFINES += -DHAVE_X11_BMF
 endif
 
 


### PR DESCRIPTION
This commit makes it possible to have xft+bitmap fonts (both or either).

Currently bitmap fonts are always enabled, (to use when "xft:" prefix isnt found).

Note that we could disable bitmap support entirely by not defining `HAVE_X11_BMF`, In the current makefiles this isnt done.