### PR TITLE
Support for window placement under mouse pointer

### DIFF
--- a/etc/cfg_notion.lua
+++ b/etc/cfg_notion.lua
@@ -66,6 +66,10 @@ ioncore.set{
     -- Auto-unsqueeze transients/menus/queries.
     --unsqueeze=true,
 
+    -- Float window placement method:
+    -- one of 'udlr' (up down left right), 'lrud' (left right up down), 'pointer' or 'random'.
+    --float_placement_method="udlr"
+
     -- Float non-transient dialog type windows.
     -- Can be useful for applications that try to place their own dialog windows.
     --window_dialog_float=true,

--- a/ioncore/conf.c
+++ b/ioncore/conf.c
@@ -84,7 +84,8 @@ static ExtlFn get_layout_fn;
  *  \var{framed_transients} & (boolean) Put transients in nested frames. \\
  *  \var{float_placement_method} & (string) How to place floating frames.
  *                          One of \codestr{udlr} (up-down, then left-right),
- *                          \codestr{lrud} (left-right, then up-down), or
+ *                          \codestr{lrud} (left-right, then up-down),
+ *                          \codestr{pointer} to place under the pointer or
  *                          \codestr{random}. \\
  *  \var{float_placement_padding} & (integer) Pixels between frames when
  *                          \var{float_placement_method} is \codestr{udlr} or

--- a/ioncore/float-placement.c
+++ b/ioncore/float-placement.c
@@ -9,6 +9,8 @@
 #include <string.h>
 
 #include "common.h"
+#include "rootwin.h"
+#include "xwindow.h"
 #include "group.h"
 #include "float-placement.h"
 
@@ -167,10 +169,28 @@ static bool tiling_placement(WGroup *ws, uint level, WRectangle *g)
 
 }
 
+static bool pointer_placement(WGroup *ws, WRectangle *g)
+{
+    WRootWin *rootwin=region_rootwin_of((WRegion*)ws);
+    int px=0, py=0;
+
+    if(xwindow_pointer_pos(WROOTWIN_ROOT(rootwin), &px, &py)){
+        const WRectangle r=REGION_GEOM(ws);
+        g->x=px-(g->w/2);
+        g->y=py-(g->h/2);
+        rectangle_clamp_or_center(g, &r);
+        return TRUE;
+    }
+    return FALSE;
+}
+
 
 void group_calc_placement(WGroup *ws, uint level, WRectangle *geom)
 {
-    if(ioncore_placement_method!=PLACEMENT_RANDOM){
+    if(ioncore_placement_method==PLACEMENT_POINTER){
+        if(pointer_placement(ws, geom))
+            return;
+    }else if(ioncore_placement_method!=PLACEMENT_RANDOM){
         if(tiling_placement(ws, level, geom))
             return;
     }

--- a/ioncore/float-placement.h
+++ b/ioncore/float-placement.h
@@ -12,9 +12,11 @@
 #include "common.h"
 #include "group.h"
 
-
 typedef enum{
-    PLACEMENT_LRUD, PLACEMENT_UDLR, PLACEMENT_RANDOM
+    PLACEMENT_LRUD,
+    PLACEMENT_UDLR,
+    PLACEMENT_POINTER,
+    PLACEMENT_RANDOM,
 } WFloatPlacement;
 
 extern WFloatPlacement ioncore_placement_method;

--- a/ioncore/group-ws.c
+++ b/ioncore/group-ws.c
@@ -43,6 +43,8 @@ void ioncore_groupws_set(ExtlTab tab)
             ioncore_placement_method=PLACEMENT_UDLR;
         else if(strcmp(method, "lrud")==0)
             ioncore_placement_method=PLACEMENT_LRUD;
+        else if(strcmp(method, "pointer")==0)
+            ioncore_placement_method=PLACEMENT_POINTER;
         else if(strcmp(method, "random")==0)
             ioncore_placement_method=PLACEMENT_RANDOM;
         else
@@ -56,12 +58,20 @@ void ioncore_groupws_set(ExtlTab tab)
 
 void ioncore_groupws_get(ExtlTab t)
 {
-    extl_table_sets_s(t, "float_placement_method",
-                      (ioncore_placement_method==PLACEMENT_UDLR
-                       ? "udlr"
-                       : (ioncore_placement_method==PLACEMENT_LRUD
-                          ? "lrud"
-                          : "random")));
+    const char *method;
+    if(ioncore_placement_method==PLACEMENT_UDLR){
+        method="udlr";
+    }else if(ioncore_placement_method==PLACEMENT_LRUD){
+        method="lrud";
+    }else if(ioncore_placement_method==PLACEMENT_POINTER){
+        method="pointer";
+    }else if(ioncore_placement_method==PLACEMENT_RANDOM){
+        method="random";
+    }else{
+        warn(TR("Unknown placement constant %d."), ioncore_placement_method);
+        method="random";
+    }
+    extl_table_sets_s(t, "float_placement_method", method);
     extl_table_sets_i(t, "float_placement_padding", ioncore_placement_padding);
 }
 

--- a/ioncore/rectangle.c
+++ b/ioncore/rectangle.c
@@ -23,6 +23,24 @@ void rectangle_constrain(WRectangle *g, const WRectangle *bounds)
     g->h=MAXOF(1, MINOF(bounds->y+bounds->h, tmpg.y+tmpg.h)-g->y);
 }
 
+void rectangle_clamp_or_center(WRectangle *g, const WRectangle *bounds)
+{
+    if(g->w>bounds->w){
+        g->x=(bounds->x+(bounds->w/2))-(g->w/2);
+    }else if(g->x<bounds->x){
+        g->x=bounds->x;
+    }else if(g->x+g->w>bounds->x+bounds->w){
+        g->x=(bounds->x+bounds->w)-g->w;
+    }
+
+    if(g->h>bounds->h){
+        g->y=(bounds->y+(bounds->h/2))-(g->h/2);
+    }else if(g->y<bounds->y){
+        g->y=bounds->y;
+    }else if(g->y+g->h>bounds->y+bounds->h){
+        g->y=(bounds->y+bounds->h)-g->h;
+    }
+}
 
 bool rectangle_contains(const WRectangle *g, int x, int y)
 {

--- a/ioncore/rectangle.h
+++ b/ioncore/rectangle.h
@@ -31,6 +31,7 @@ DECLSTRUCT(WRectangle){
 extern int rectangle_compare(const WRectangle *g, const WRectangle *h);
 extern bool rectangle_contains(const WRectangle *g, int x, int y);
 extern void rectangle_constrain(WRectangle *g, const WRectangle *bounds);
+extern void rectangle_clamp_or_center(WRectangle *g, const WRectangle *bounds);
 
 extern void rectange_debugprint(const WRectangle *g, const char *n);
 


### PR DESCRIPTION
Option to place new floating windows under the cursor (clamped by the workspace bounds).

Most window managers have this as an option, it's especially handy for dialog windows (may even be a good default for dialogs).