### PR TITLE
Fix bitmap font display

### DIFF
--- a/de/font.c
+++ b/de/font.c
@@ -501,7 +501,7 @@ void debrush_do_draw_string_default(
         }
 #endif
 #ifdef HAVE_X11_BMF
-        if (brush->d->font->fontset) {
+        {
             debrush_do_draw_string_default_bmf(brush, x, y, str, len, needfill, colours);
             return;
         }


### PR DESCRIPTION
Bitmap font's allocate this as needed, checking caused text not to display.