### PR TITLE
Fix #64: Add support for Lua 5.3

### DIFF
--- a/build/lua-detect.mk
+++ b/build/lua-detect.mk
@@ -13,7 +13,7 @@
 #  * LUA (full path to lua interpreter)
 #  * LUAC (full path to lua compiler)
 
-LUA_VERSIONS_CANDIDATES = $(or $(LUA_VERSION),5.2 5.1 5.0)
+LUA_VERSIONS_CANDIDATES = $(or $(LUA_VERSION),5.3 5.2 5.1 5.0)
 
 LUA_PKG := $(firstword $(foreach ver,$(LUA_VERSIONS_CANDIDATES),$(shell \
        ($(PKG_CONFIG) --exists lua-$(ver)     && echo lua-$(ver)) \
@@ -24,7 +24,7 @@ ifeq ($(LUA_PKG),)
 endif
 
 ifeq ($(LUA_VERSION),)
-LUA_VERSION := $(or $(shell $(PKG_CONFIG) --variable=V $(LUA_PKG)),5.0)
+LUA_VERSION := $(or $(shell $(PKG_CONFIG) --variable=V $(LUA_PKG)),$(or $(shell $(PKG_CONFIG) --variable=major_version $(LUA_PKG)),5.0))
 endif
 
 # prior to 5.1 the lib didn't include version in name.

--- a/contrib/statusd/legacy/statusd_sysmon.lua
+++ b/contrib/statusd/legacy/statusd_sysmon.lua
@@ -17,6 +17,8 @@
 -- If it works as a Ion statusd monitor, it reads user settings from statusd.
 
 if not statusd_sysmon then
+local loadstring = loadstring or load
+
 statusd_sysmon = {
     -- UPDATE INTERVAL
     --

--- a/ioncore/ioncore_bindings.lua
+++ b/ioncore/ioncore_bindings.lua
@@ -7,6 +7,7 @@
 --
 
 local ioncore=_G.ioncore
+local loadstring = loadstring or load
 
 local warn=ioncore.warn
 

--- a/mod_query/mod_query.lua
+++ b/mod_query/mod_query.lua
@@ -17,10 +17,9 @@ if not ioncore.load_module("mod_query") then
 end
 
 local mod_query=_G["mod_query"]
-local loadstring = loadstring or load
-
 assert(mod_query)
 
+local loadstring = loadstring or load
 
 local DIE_TIMEOUT_ERRORCODE=10 -- 10 seconds
 local DIE_TIMEOUT_NO_ERRORCODE=2 -- 2 seconds

--- a/mod_query/mod_query.lua
+++ b/mod_query/mod_query.lua
@@ -17,6 +17,7 @@ if not ioncore.load_module("mod_query") then
 end
 
 local mod_query=_G["mod_query"]
+local loadstring = loadstring or load
 
 assert(mod_query)
 

--- a/mod_xinerama/mod_xinerama.lua
+++ b/mod_xinerama/mod_xinerama.lua
@@ -31,7 +31,7 @@ local mod_xinerama=_G["mod_xinerama"]
 assert(mod_xinerama)
 
 
-local function table_maxn(tbl)
+local table_maxn = table.maxn or function(tbl)
    local c=0
    for k in pairs(tbl) do c=c+1 end
    return c

--- a/mod_xinerama/mod_xinerama.lua
+++ b/mod_xinerama/mod_xinerama.lua
@@ -31,6 +31,11 @@ local mod_xinerama=_G["mod_xinerama"]
 assert(mod_xinerama)
 
 
+local function table_maxn(tbl)
+   local c=0
+   for k in pairs(tbl) do c=c+1 end
+   return c
+end
 -- Helper functions {{{
 
 local function max(one, other)
@@ -176,7 +181,7 @@ function mod_xinerama.merge_overlapping_screens(screens)
 		end
 	    end
 	end
-	if not pos then pos = table.maxn(ret)+1 end
+	if not pos then pos = table_maxn(ret)+1 end
 	table.insert(ret, pos, newscreen)
     end
     fix_representations(ret)
@@ -276,7 +281,7 @@ function mod_xinerama.merge_overlapping_screens_alternative(screens)
 
 	-- pos keeps index of first set that we merged in this loop,
 	-- we want to insert the product of this merge to pos.
-	if not pos then pos = table.maxn(screensets)+1 end
+	if not pos then pos = table_maxn(screensets)+1 end
 	table.insert(screensets, pos, mergedset)
     end
 


### PR DESCRIPTION
Changed lua-detect.mk to correctly detect Lua 5.3 and also pkg-config using major_version instead of V variable.
Also, there were some methods were deprecated in Lua 5.3, I changed the code to remain compatible with prior versions while supporting 5.3.

Fixes #64 