### PR TITLE
Support for showing tab numbers while a key is pressed

### DIFF
--- a/ioncore/eventh.c
+++ b/ioncore/eventh.c
@@ -464,13 +464,13 @@ void ioncore_handle_buttonpress(XEvent *ev)
     XEvent tmp;
     bool finished=FALSE;
 
-    if(ioncore_grab_held())
+    if(ioncore_pointer_grab_held())
         return;
 
     if(!ioncore_do_handle_buttonpress(&(ev->xbutton)))
         return;
 
-    while(!finished && ioncore_grab_held()){
+    while(!finished && ioncore_pointer_grab_held()){
         XFlush(ioncore_g.dpy);
         ioncore_get_event(ev, IONCORE_EVENTMASK_PTRLOOP);
 

--- a/ioncore/frame.h
+++ b/ioncore/frame.h
@@ -111,6 +111,8 @@ extern bool frame_is_shaded(WFrame *frame);
 extern bool frame_set_numbers(WFrame *frame, int sp);
 extern bool frame_is_numbers(WFrame *frame);
 
+extern void frame_hint(WFrame *frame);
+
 extern int frame_default_index(WFrame *frame);
 
 /* Misc */

--- a/ioncore/grab.h
+++ b/ioncore/grab.h
@@ -17,26 +17,48 @@
 #include "common.h"
 #include "region.h"
 
+// Grab flags:
+#define GRAB_KEYBOARD 0x0100
+#define GRAB_POINTER  0x0200
+
+#define GRAB_DEFAULT_FLAGS (GRAB_KEYBOARD|GRAB_POINTER)
+
+// GrabHandler result flags:
+#define GRAB_COMPLETE 0x0001
+#define GRAB_FORWARD  0x0002
+
 /* GrabHandler:
    the default_keyboard_handler now simplifies access to subsequent keypresses
    when you establish a grab using grab_establish().
 
-   if your GrabHandler returns TRUE, your grab will be removed, otherwise it's
+   A GrabHandler returns a bitmap with actions to take after the grab:
+   - GRAB_COMPLETE remove the grab
+   - GRAB_FORWARD forward the grabbed event to the event handler
    kept active and you get more grabbed events passed to your handler.
  */
-typedef bool GrabHandler(WRegion *reg, XEvent *ev);
+typedef int GrabHandler(WRegion *reg, XEvent *ev);
 typedef void GrabKilledHandler(WRegion *reg);
 
+/**
+ * @param eventmask mask of X11 events *not* to grab. Usually 0.
+ * @param flags grab flags, usually GRAB_DEFAULT_FLAGS.
+ */
 extern void ioncore_grab_establish(WRegion *reg, GrabHandler *func,
-                                   GrabKilledHandler *kh,long eventmask);
+                                   GrabKilledHandler *kh,
+                                   long eventmask, int flags);
 extern void ioncore_grab_remove(GrabHandler *func);
 extern void ioncore_grab_holder_remove(WRegion *holder);
 extern WRegion *ioncore_grab_get_holder();
 extern WRegion *ioncore_grab_get_my_holder(GrabHandler *func);
 extern bool ioncore_grab_held();
+/** if the current grab, if any, also holds the mouse pointer */
+extern bool ioncore_pointer_grab_held();
 extern void ioncore_change_grab_cursor(int cursor);
 extern void ioncore_grab_confine_to(Window confine_to);
 
+/**
+ * @returns TRUE if the event was consumed, FALSE if it must still be processed
+ */
 extern bool ioncore_handle_grabs(XEvent *ev);
 
 #endif /* ION_IONCORE_GRAB_H */

--- a/ioncore/kbresize.c
+++ b/ioncore/kbresize.c
@@ -389,7 +389,8 @@ WMoveresMode *region_begin_kbresize(WRegion *reg)
     accel_reset();
 
     ioncore_grab_establish(reg, resize_handler,
-                           (GrabKilledHandler*)cancel_moveres, 0);
+                           (GrabKilledHandler*)cancel_moveres,
+                           0, GRAB_DEFAULT_FLAGS);
 
     return mode;
 }

--- a/ioncore/key.c
+++ b/ioncore/key.c
@@ -87,7 +87,9 @@ static bool quote_next_handler(WRegion *reg, XEvent *xev)
 EXTL_EXPORT_MEMBER
 void clientwin_quote_next(WClientWin *cwin)
 {
-    ioncore_grab_establish((WRegion*)cwin, quote_next_handler, NULL, 0);
+    ioncore_grab_establish((WRegion*)cwin,
+                           quote_next_handler, NULL,
+                           0, GRAB_DEFAULT_FLAGS);
     ioncore_change_grab_cursor(IONCORE_CURSOR_WAITKEY);
 }
 
@@ -111,8 +113,8 @@ static void waitrelease(WRegion *reg)
      * be removed before the modifiers are released.
      */
     ioncore_grab_establish((WRegion*)region_rootwin_of(reg),
-                           waitrelease_handler,
-                           NULL, 0);
+                           waitrelease_handler, NULL,
+                           0, GRAB_DEFAULT_FLAGS);
     ioncore_change_grab_cursor(IONCORE_CURSOR_WAITKEY);
 }
 
@@ -269,7 +271,8 @@ static bool submapgrab_handler(WRegion* reg, XEvent *xev)
 
 static void submapgrab(WRegion *reg)
 {
-    ioncore_grab_establish(reg, submapgrab_handler, clear_subs, 0);
+    ioncore_grab_establish(reg, submapgrab_handler, clear_subs,
+                           0, GRAB_DEFAULT_FLAGS);
     ioncore_change_grab_cursor(IONCORE_CURSOR_WAITKEY);
 }
 

--- a/ioncore/pointer.c
+++ b/ioncore/pointer.c
@@ -274,7 +274,8 @@ bool ioncore_do_handle_buttonpress(XButtonEvent *ev)
                                              button, p_area);
     }
 
-    ioncore_grab_establish(reg, handle_key, pointer_grab_killed, 0);
+    ioncore_grab_establish(reg, handle_key, pointer_grab_killed,
+                           0, GRAB_DEFAULT_FLAGS);
     p_grabstate=ST_HELD;
 
     call_button(pressbind, ev);

--- a/mod_menu/grabmenu.c
+++ b/mod_menu/grabmenu.c
@@ -107,7 +107,7 @@ WMenu *mod_menu_do_grabmenu(WMPlex *mplex, ExtlFn handler, ExtlTab tab,
     menu->gm_state=state;
 
     ioncore_grab_establish((WRegion*)menu, grabmenu_handler,
-                           grabkilled_handler, 0);
+                           grabkilled_handler, 0, GRAB_DEFAULT_FLAGS);
 
     return menu;
 }

--- a/mod_mgmtmode/mgmtmode.c
+++ b/mod_mgmtmode/mgmtmode.c
@@ -208,7 +208,8 @@ WMgmtMode *mod_mgmtmode_begin(WRegion *reg)
 
     ioncore_grab_establish((WRegion*)region_rootwin_of(reg),
                            mgmt_handler,
-                           (GrabKilledHandler*)cancel_mgmt, 0);
+                           (GrabKilledHandler*)cancel_mgmt, 0,
+                           GRAB_DEFAULT_FLAGS);
 
     mgmtmode_draw(mgmt_mode);
 


### PR DESCRIPTION
With this change, you can register keybindings to show tab numbers while
holding a key, e.g.:

```
defbindings("WFrame.toplevel", {
    kpress("Super_L", "WFrame.set_numbers(_, 'during_grab')"),
})
```

The grab is necessary to be able to restore the normal titles again when the
key is released. A feature was added to 'grab' to allow grabbing the keyboard
while still processing mouse events (such as resizing frames with META+Button3).