### PR TITLE
rewrite of notionflux with REPL, line-editing and so forth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   exclude:
     - compiler: clang
       env: C99_SOURCE=""
-before_install: sudo apt-get install lua5.2 liblua5.2-dev gettext libxft-dev libxinerama-dev libxrandr-dev
+before_install: sudo apt-get install lua5.2 liblua5.2-dev gettext libxft-dev libxinerama-dev libxrandr-dev libreadline-dev
 script:
   - make
   - make test

--- a/man/Makefile
+++ b/man/Makefile
@@ -33,7 +33,7 @@ notion.%.1: notion.%.in $(CONFIGS) ../po/%.po
 	$(MKMAN) -po ../po/$*.po -i $< -o $@ -D ETCDIR $(ETCDIR) -D DOCDIR $(DOCDIR) $(CONFIGS)
 
 notionflux.1: notionflux.in $(CONFIGS)
-	$(MKMAN) -i $< -o $@ $(CONFIGS)
+	$(MKMAN) -i $< -o $@ -D DOCDIR $(DOCDIR) $(CONFIGS)
 
 welcome%txt: welcome%head notion%1
 	(cat welcome$*head; \

--- a/man/notionflux.in
+++ b/man/notionflux.in
@@ -1,86 +1,108 @@
-.TH NOTIONFLUX 1
-.SH NAME
-Notionflux - lua remote control for Notion.
-.SH SYNOPSIS
-.B notionflux
-.I "[-e code]"
-.SH "DESCRIPTION"
-
-.B notionflux
-allows you to access the notion lua scripting interface from the
-command\-line. It either takes a script from stdin or through the \'\-e\'
-parameter.
-
-The lua script will be executed by the Lua engine running in Notion, which
-means it has access to the Notion lua api (notioncore.* et al). Calls to
-\'print\' will print values to Notion\'s stdout (e.g. ~/.xsession\-errors).
-The scripts\' return value will be printed by
-.B notionflux
-.
-
-.SH "OPTIONS"
-.TP
-.B \-e code
-Lua code to execute.
-
-.SH "ENVIRONMENT"
-
-.B notionflux
-talks to
-.BR notion (1)
-through a socket, which is determined by the
-.B _NOTION_MOD_NOTIONFLUX_SOCKET
-property on the root of the display on which
-.BR notion (1)
-is running.
-
-.SH "SECURITY"
-
+.\" Copyright (c) 2019 Moritz Wilhelmy
+.\" This file is hereby licensed Creative Commons CC0 - no rights reserved
+.\" For more information, see https://creativecommons.org/share-your-work/public-domain/cc0/
+.\" This is an mdoc(7) manual page, as any manual page should be.
+.Dd June 20, 2019
+.Os notion
+.Dt notionflux 1
+.Sh NAME
+.Nm notionflux
+.Nd Lua remote control for notion
+.Sh SYNOPSIS
+.Nm Op Fl e Ar lua-code
+.Pp
+.Nm Op Fl R
+.Sh DESCRIPTION
+.Nm
+is a tool to send scripts to the Lua scripting engine inside the
+.Xr notion 1
+window manager. The script can thus access notion's internal Lua API.
+.Pp
+There are two modes of operation, interactive and batch.
+Interactive mode is enabled by running
+.Nm
+with its standard input connected to a terminal and without passing any commandline flags.
+.Pp
+Otherwise, batch mode is enabled:
+.Bl -tag -width Ds
+.It Fl R
+Force batch-mode even if stdin is connected to a terminal.
+Lua code is read from stdin until the end-of-file is reached,
+is sent to notion for processing, and the result is read back and displayed.
+.It Fl e Ar code
+Almost the same as above, except instead of reading from stdin, the command line parameter
+.Ar code
+is submitted for processing.
+.El
+.Sh INTERACTIVE MODE
+This mode is similar to running an interactive
+.Xr lua 1
+shell. Tab completion for notion's Lua API is available, as well as line-editing.
+.Pp
+Code that has been entered is evaluated by notion as soon as it is a complete
+Lua statement. The result is displayed after which the next statement can be
+entered.
+.Sh ENVIRONMENT
+.Bl -tag -width DISPLAY
+.It Ev DISPLAY
 The
-.B notionflux
-socket is created with read/write permissions only for the user who started
-.BR notion (1).
-Neither
-.BR notion (1)
-nor
-.B notionflux
-are
-.BR setuid (2),
-so
-.B notionflux
-should not pose any security threat.
-
-.SH "EXAMPLES"
-Write \'foo\' to
-.BR notion (1)\'s
-stdout and \'bar\' to the terminal, specifying the script on the commandline:
-.PP
-.nf
-.RS
-$ notionflux \-e "print('foo'); return 'bar'"
-"bar"
-.RE
-.fi
-.PP
-Or the same, but now via STDIN:
-.PP
-.nf
-.RS
-$ echo "print('foo'); return 'bar'" | notionflux
-"bar"
-.RE
-.fi
-.PP
-
-.SH SEE ALSO
-The Notion home page, \fIhttps://notionwm.net/\fP
-.PP
-The document "Configuring and extending Notion with Lua" found on the
-Notion home page.
-.PP
-.I DOCDIR/
-.PP
-\fIX(7x)\fP, \fInotionflux(1)\fP
-
-.SH AUTHOR
-Notionflux was written by the Notion team, based on ionflux which was written by Tuomo Valkonen <tuomov at iki.fi>.
+.Ev DISPLAY
+environment variable must be set to an X server running notion in order for
+.Nm
+to obtain the socket path.
+.El
+.Sh SECURITY
+.Nm
+connects to
+.Xr notion 1
+through a Unix domain socket. This socket is created with read/write permissions
+only for the user who started notion. The socket path can be queried with the following command:
+.Bd -literal -offset indent
+.Ic $ xprop Fl root Cm _NOTION_MOD_NOTIONFLUX_SOCKET
+_NOTION_MOD_NOTIONFLUX_SOCKET(STRING) = "/tmp/fileuj6onu"
+.Ed
+.Pp
+.Sh EXAMPLES
+The command
+.Bd -literal -offset indent
+.Ic $ Nm Fl e Qq Cm return notioncore.current():name()
+"emacs: notionflux.1"
+.Ed
+.Pp
+will display the title of the currently focused window, while
+.Bd -literal -offset indent
+.Ic $ Nm Fl e Qq Cm print(notioncore.current():name())
+nil
+.Ed
+.Pp
+will print the message to notion's standard output (usually
+.Pa ~/.xsession\-errors )
+.Pp
+In any response from mod_notionflux, strings are quoted in a way that can be
+directly pasted back into a Lua interpreter to yield the same string, while
+other types are turned into their string representation using
+.Fn tostring .
+This is why there are quotation marks around the response in the first example
+where nil (which is the return value of a block which has no return statement)
+does not have them.
+.Sh SEE ALSO
+.Lk https://notionwm.net/ "The notion homepage"
+.Pp
+The document
+.Dq Configuring and extending Notion with Lua
+found on the Notion homepage.
+.Pp
+.Pa DOCDIR/
+.Pp
+.Xr notion 1 ,
+.Xr X 7 ,
+.Xr lua 1 ,
+.Xr readline 3
+.Sh HISTORY
+An ionflux command appeared in ion3 around 2004. It was adapted to notion by the
+notion development team when notion was forked from ion3 in 2010.
+.Sh AUTHOR
+.Nm
+was rewritten in 2019 by
+.An Moritz Wilhelmy
+under the GNU GPL in order to add the interactive mode.

--- a/mod_notionflux/notionflux/Makefile
+++ b/mod_notionflux/notionflux/Makefile
@@ -12,7 +12,7 @@ SOURCES=notionflux.c
 
 TARGETS=notionflux
 
-CFLAGS += $(XOPEN_SOURCE)
+CFLAGS += $(XOPEN_SOURCE) -std=c99
 
 INCLUDES += $(X11_INCLUDES) -I$(TOPDIR)
 

--- a/mod_notionflux/notionflux/Makefile
+++ b/mod_notionflux/notionflux/Makefile
@@ -4,6 +4,7 @@
 
 # System-specific configuration is in system.mk
 TOPDIR=../..
+USE_READLINE := 1
 include $(TOPDIR)/build/system-inc.mk
 
 ######################################
@@ -12,11 +13,11 @@ SOURCES=notionflux.c
 
 TARGETS=notionflux
 
-CFLAGS += $(XOPEN_SOURCE) -std=c99
+CFLAGS += $(C99_SOURCE)
 
-INCLUDES += $(X11_INCLUDES) -I$(TOPDIR)
+INCLUDES += $(X11_INCLUDES) $(LUA_INCLUDES) $(READLINE_INCLUDES) -I$(TOPDIR)
 
-LIBS += $(X11_LIBS)
+LIBS += $(X11_LIBS) $(LUA_LIBS) $(READLINE_LIBS)
 
 EXTRA_EXECUTABLE = notionflux
 

--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -320,6 +320,8 @@ int repl_main(void)
 		if (line[0] == '\0') /* empty line, skip */
 			continue;
 
+		add_history(line);
+
 		if (!input_append(line) || !input_append("\n")) {
 			printf("Maximum length (%db) exceeded.\n", MAX_DATA);
 			input_reset();

--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -268,11 +268,11 @@ int repl_main(void)
 		line = readline(prompt);
 
 		if (!line) { /* EOF */
+			puts("^D");
 			if (!input.pos) {           /* quit */
-				break;
+				return 0;
 			} else {    /* abort previous input */
 				input_reset();
-				puts("^D");
 				continue;
 			}
 		}
@@ -298,9 +298,7 @@ int repl_main(void)
 			fputs(out, stdout);
 		input_reset();
 	}
-	free(line);
-
-	return 0;
+	/* unreachable */
 }
 
 int main(int argc, char **argv)

--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -168,9 +168,13 @@ bool buf_append(struct buf *buf, char const *str)
 
 void buf_grow(struct buf **buf, size_t n)
 {
-	*buf = realloc(*buf, (*buf)->size+n);
+	size_t newsize = sizeof(*buf) - sizeof((*buf)->buf) + (*buf)->size + n;
+	size_t pos = buf_pos(*buf);
+	*buf = realloc(*buf, newsize);
 	if (!*buf)
 		die("realloc failed\n");
+	(*buf)->size = newsize;
+	(*buf)->cur = (*buf)->buf + pos;
 }
 
 void *alloc(size_t bytes)

--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -44,11 +44,11 @@ char const *sockfilename = NULL;
 char const *get_socket_filename(void)
 {
 	Display *dpy = XOpenDisplay(NULL);
-        if (!dpy)
+	if (!dpy)
 		die("Failed to open display\n");
 
 	Window root = DefaultRootWindow(dpy);
-        Atom sockname_prop = XInternAtom(dpy, SOCK_ATOM, True);
+	Atom sockname_prop = XInternAtom(dpy, SOCK_ATOM, True);
 	if (sockname_prop == None)
 		die("No %s property set on the root window... is notion "
 		    "running with mod_notionflux loaded?\n", SOCK_ATOM);
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
 {
 	sockfilename = get_socket_filename();
 	FILE *remote = sock_connect();
-        char buf[MAX_DATA + 1];
+	char buf[MAX_DATA + 1];
 	char *data;
 
 	if (argc == 1) {
@@ -129,15 +129,15 @@ int main(int argc, char **argv)
 	if (!bytes)
 		die("fread failed\n");
 
-        char type = buf[0];
-        if (type != 'S' && type != 'E')
+	char type = buf[0];
+	if (type != 'S' && type != 'E')
 		die("Unknown response type '%c'(%x)\n", type, type);
 
-        fputs(buf+1, type == 'S' ? stdout : stderr);
-        do {
+	fputs(buf+1, type == 'S' ? stdout : stderr);
+	do {
 		bytes = slurp(remote, buf, MAX_DATA);
 		fputs(buf, type == 'S' ? stdout : stderr);
 	} while (bytes == MAX_DATA);
 
-        return 0;
+	return 0;
 }

--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -168,12 +168,13 @@ bool buf_append(struct buf *buf, char const *str)
 
 void buf_grow(struct buf **buf, size_t n)
 {
-	size_t newsize = sizeof(*buf) - sizeof((*buf)->buf) + (*buf)->size + n;
+	size_t bufsize = (*buf)->size + n;
+	size_t structsize = bufsize + (sizeof(struct buf) - sizeof((*buf)->buf));
 	size_t pos = buf_pos(*buf);
-	*buf = realloc(*buf, newsize);
+	*buf = realloc(*buf, structsize);
 	if (!*buf)
 		die("realloc failed\n");
-	(*buf)->size = newsize;
+	(*buf)->size = bufsize;
 	(*buf)->cur = (*buf)->buf + pos;
 }
 

--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -259,11 +259,12 @@ bool is_lua_incomplete(char *lua, size_t len)
 
 int repl_main(void)
 {
-	char *line;
+	char *line = NULL;
 	char const *prompt = "lua> ";
 	rl_startup_hook = initialize_readline;
 
 	while (1) {
+		free(line);
 		line = readline(prompt);
 
 		if (!line) { /* EOF */
@@ -297,6 +298,7 @@ int repl_main(void)
 			fputs(out, stdout);
 		input_reset();
 	}
+	free(line);
 
 	return 0;
 }

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -114,6 +114,13 @@ else
     DEFINES += -DHAVE_X11_BMF
 endif
 
+##
+## GNU readline, currently only used by mod_notionflux/notionflux
+##
+ifeq ($(USE_READLINE),1)
+    READLINE_INCLUDES += $(shell pkg-config readline --cflags)
+    READLINE_LIBS += $(shell pkg-config readline --libs)
+endif
 
 ##
 ## Localisation

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -118,8 +118,12 @@ endif
 ## GNU readline, currently only used by mod_notionflux/notionflux
 ##
 ifeq ($(USE_READLINE),1)
-    READLINE_INCLUDES += $(shell pkg-config readline --cflags)
-    READLINE_LIBS += $(shell pkg-config readline --libs)
+    # Debian does not install readline.pc
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=901650
+    READLINE_INCLUDES_FALLBACK := -D_XOPEN_SOURCE=600 -I/usr/include/readline
+    READLINE_LIBS_FALLBACK := -lreadline
+    READLINE_INCLUDES ?= $(shell pkg-config readline --cflags || echo $(READLINE_INCLUDES_FALLBACK))
+    READLINE_LIBS ?= $(shell pkg-config readline --libs || echo $(READLINE_LIBS_FALLBACK))
 endif
 
 ##


### PR DESCRIPTION
As mentioned on IRC I've rewritten notionflux.

Notable features:

* Dual-licensed as LGPL/GPL to conform with notion's license as well as GNU readline's, a bit of a hack. (LGPL wouldn't be required but this should allow for shipping the source package entirely under an LGPL label...? I'm not a lawyer and I can change it to plain GPL if that simplifies things)
* readline for line-editing
* REPL mode, uses mod_notionflux and mod_query on the notion side to tab-complete lua expressions
* linked against lua now to check whether a statement is complete before it is sent

Please test and enjoy!