### PR TITLE
Send output of 'print' statements in notionflux scripts to the invoking shell

### DIFF
--- a/libextl/luaextl.h
+++ b/libextl/luaextl.h
@@ -94,6 +94,8 @@ extern bool extl_table_get_vararg(ExtlTab ref, char itype, char type,
                                   va_list *args);
 extern bool extl_table_get(ExtlTab ref, char itype, char type, ...);
 
+extern bool extl_lookup_global_value(void *out, char type, ...);
+
 extern bool extl_table_gets_a(ExtlTab ref, const char *entry, ExtlAny *ret);
 extern bool extl_table_gets_o(ExtlTab ref, const char *entry, Obj **ret);
 extern bool extl_table_gets_i(ExtlTab ref, const char *entry, int *ret);

--- a/man/notionflux.in
+++ b/man/notionflux.in
@@ -3,22 +3,19 @@
 .\" For more information, see https://creativecommons.org/share-your-work/public-domain/cc0/
 .\" This is an mdoc(7) manual page, as any manual page should be.
 .Dd June 20, 2019
-.Os notion
 .Dt notionflux 1
+.Os notion
 .Sh NAME
 .Nm notionflux
 .Nd Lua remote control for notion
 .Sh SYNOPSIS
-.Nm Op Fl e Ar lua-code
-.Pp
-.Nm Op Fl R
-.Pp
-.Nm Op Pa file
+.Nm Op Fl R | Fl e Ar lua-code | Pa file
 .Sh DESCRIPTION
 .Nm
 is a tool to send scripts to the Lua scripting engine inside the
 .Xr notion 1
-window manager. The script can thus access notion's internal Lua API.
+window manager.
+The script can thus access notion's internal Lua API.
 .Pp
 There are two modes of operation, interactive and batch.
 Interactive mode is enabled by running
@@ -41,11 +38,12 @@ The content of the file is evaluated.
 .Sh INTERACTIVE MODE
 This mode is similar to running an interactive
 .Xr lua 1
-shell. Tab completion for notion's Lua API is available, as well as line-editing.
+shell.
+Tab completion for notion's Lua API is available, as well as line-editing.
 .Pp
 Code that has been entered is evaluated by notion as soon as it is a complete
-Lua statement. The result is displayed after which the next statement can be
-entered.
+Lua statement.
+The result is displayed after which the next statement can be entered.
 .Sh ENVIRONMENT
 .Bl -tag -width DISPLAY
 .It Ev DISPLAY
@@ -59,23 +57,23 @@ to obtain the socket path.
 .Nm
 connects to
 .Xr notion 1
-through a Unix domain socket. This socket is created with read/write permissions
-only for the user who started notion. The socket path can be queried with the following command:
+through a Unix domain socket.
+This socket is created with read/write permissions only for the user who started notion.
+The socket path can be queried with the following command:
 .Bd -literal -offset indent
-.Ic $ xprop Fl root Cm _NOTION_MOD_NOTIONFLUX_SOCKET
+$ xprop \-root _NOTION_MOD_NOTIONFLUX_SOCKET
 _NOTION_MOD_NOTIONFLUX_SOCKET(STRING) = "/tmp/fileuj6onu"
 .Ed
-.Pp
 .Sh EXAMPLES
 The command
 .Bd -literal -offset indent
-.Ic $ Nm Fl e Qq return notioncore.current():name()
+$ notionflux -e "return notioncore.current():name()"
 "emacs: notionflux.1"
 .Ed
 .Pp
 will display the title of the currently focused window, while
 .Bd -literal -offset indent
-.Ic $ Nm Fl e Qq print(notioncore.current():name())
+$ notionflux -e "print(notioncore.current():name())"
 "emacs: notionflux.1"
 nil
 .Ed
@@ -93,13 +91,13 @@ nil
 .Pp
 Using input redirection:
 .Bd -literal -offset indent
-.Ic $ Cm echo Qo return notioncore.current() Qc | Nm Op Fl R
+$ echo "return notioncore.current()" | notionflux
 WClientWin: 0x9bb6b8
 .Ed
 .Pp
 Using interactive mode:
 .Bd -literal -offset indent
-.Ic $ Nm
+$ notionflux
 lua> notioncore.current():rootwin_of()
 WRootWin: 0x8c9688
 lua> do
@@ -120,9 +118,7 @@ does not have them.
 .Sh SEE ALSO
 .Lk https://notionwm.net/ "The notion homepage"
 .Pp
-The document
-.Dq Configuring and extending Notion with Lua
-found on the Notion homepage.
+.Lk http://notion.sourceforge.net/notionconf/ "Configuring and extending Notion with Lua"
 .Pp
 .Lk https://www.lua.org/manual/LUA_REFVERSION/manual.html "The Lua LUA_REFVERSION reference manual"
 .Pp
@@ -133,14 +129,14 @@ found on the Notion homepage.
 .Xr lua 1 ,
 .Xr readline 3
 .Sh HISTORY
-An ionflux command appeared in ion3 around 2004. It was adapted to notion by the
-notion development team when notion was forked from ion3 in 2010.
-.Sh AUTHOR
+An ionflux command appeared in ion3 around 2004.
+It was adapted to notion by the notion development team when notion was forked from ion3 in 2010.
+.Sh AUTHORS
 .Nm
 was rewritten in 2019 by
 .An Moritz Wilhelmy
 under the GNU GPL in order to add the interactive mode.
 .Sh BUGS
-Currently, the script must be 4095 bytes or shorter. If you need more, consider
-passing a filename, which is passed to notion for evaluation and therefore
-circumvents this limit.
+Currently, the script must be 4095 bytes or shorter.
+If you need more, consider passing a filename, which is passed to notion for
+evaluation and therefore circumvents this limit.

--- a/man/notionflux.in
+++ b/man/notionflux.in
@@ -76,11 +76,20 @@ The command
 will display the title of the currently focused window, while
 .Bd -literal -offset indent
 .Ic $ Nm Fl e Qq print(notioncore.current():name())
+"emacs: notionflux.1"
 nil
 .Ed
 .Pp
-will print the message to notion's standard output (usually
-.Pa ~/.xsession\-errors ) .
+will collect the messages and print them before returning.
+In order to write to notion's standard output (usually
+.Pa ~/.xsession\-errors ) ,
+like print used to in previous versions of
+.Nm ,
+please use
+.Bd -literal -offset indent
+$ notionflux -e 'io.stdout:write("hello .xsession-errors!\\n")'
+nil
+.Ed
 .Pp
 Using input redirection:
 .Bd -literal -offset indent

--- a/mod_notionflux/Makefile
+++ b/mod_notionflux/Makefile
@@ -18,6 +18,7 @@ CFLAGS += $(XOPEN_SOURCE) $(C99_SOURCE)
 
 SOURCES=mod_notionflux.c
 
+MODULE_STUB=mod_notionflux.lua
 MODULE=mod_notionflux
 
 ######################################

--- a/mod_notionflux/Makefile
+++ b/mod_notionflux/Makefile
@@ -17,6 +17,7 @@ INCLUDES += $(X11_INCLUDES) -I$(TOPDIR)
 CFLAGS += $(XOPEN_SOURCE) $(C99_SOURCE)
 
 SOURCES=mod_notionflux.c
+MAKE_EXPORTS=mod_notionflux
 
 MODULE_STUB=mod_notionflux.lua
 MODULE=mod_notionflux

--- a/mod_notionflux/mod_notionflux.c
+++ b/mod_notionflux/mod_notionflux.c
@@ -234,6 +234,7 @@ closefd:
 /**EXTL_DOC
  * Write \var{str} to the output file descriptor associated with client \var{idx}
  */
+EXTL_SAFE
 EXTL_EXPORT
 bool mod_notionflux_xwrite(int idx, const char *str)
 {

--- a/mod_notionflux/mod_notionflux.c
+++ b/mod_notionflux/mod_notionflux.c
@@ -2,6 +2,7 @@
  * mod_notionflux/mod_notionflux/mod_notionflux.c
  *
  * Copyright (c) Tuomo Valkonen 2004-2005.
+ * Copyright (c) Moritz Wilhelmy 2019
  *
  * This is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by
@@ -30,9 +31,11 @@
 #include <libextl/luaextl.h>
 
 #include "notionflux.h"
+#include "exports.h"
 
 typedef struct{
     int fd;
+    FILE *stdout;
     int ndata;
     char *data;
 } Buf;
@@ -60,12 +63,82 @@ static void close_conn(Buf *buf)
     close(buf->fd);
     buf->fd=-1;
     buf->ndata=0;
+    if(buf->stdout!=NULL){
+        fclose(buf->stdout);
+        buf->stdout=NULL;
+    }
     if(buf->data!=NULL){
         free(buf->data);
         buf->data=NULL;
     }
 }
 
+/* Receive file descriptors from a unix domain socket.
+   See unix(4), unix(7), sendmsg(2), cmsg(3) */
+static int unix_recv_fd(int unix)
+{
+    /* tasty, tasty boilerplate. */
+    struct msghdr msg={0};
+    struct cmsghdr *cmsg;
+    struct iovec iov;
+    unsigned char magic[4]={23, 42, 128, 7};
+    char iov_buf[4];
+    int fd=-1;
+    union { /* alignment, alignment, cmsg(3) */
+        char buf[CMSG_SPACE(sizeof(fd))];
+        struct cmsghdr align;
+    } u;
+    int iter=0, rv;
+
+    iov.iov_len=sizeof(iov_buf);
+    iov.iov_base=&iov_buf;
+
+    msg.msg_name=NULL;
+    msg.msg_namelen=0;
+    msg.msg_iov=&iov;
+    msg.msg_iovlen=1;
+
+    msg.msg_control=&u.buf;
+    msg.msg_controllen=sizeof(u.buf);
+
+    rv=recvmsg(unix, &msg, MSG_CMSG_CLOEXEC);
+    if (rv== -1){
+        warn("Failed to receive fd from unix domain socket.");
+        return -1;
+    }else if(rv==0){ /* remote socket was shut down */
+        return -2;
+    }
+
+    if(memcmp(iov_buf, magic, sizeof(magic))!=0){
+        warn("Magic number mismatch on notionflux socket - "
+             "is notionflux the same version as notion?");
+        return -1;
+    }
+
+    for (cmsg=CMSG_FIRSTHDR(&msg); cmsg!=NULL; cmsg=CMSG_NXTHDR(&msg, cmsg)) {
+        if(iter>0){
+            warn("notionflux client is sending us unexpected packets");
+        }else if(cmsg->cmsg_level == SOL_SOCKET
+              && cmsg->cmsg_type == SCM_RIGHTS
+              && cmsg->cmsg_len == CMSG_LEN(sizeof(fd))){
+            unsigned char const *data=CMSG_DATA(cmsg);
+            int newfd=*((int *)data);
+            if (newfd == -1) {
+                warn("notionflux managed to send invalid fd.");
+            }else if (fd != -1 && newfd != fd) {
+                warn("notionflux client is spamming us with fds, ignoring.");
+                close(newfd); /* only want one fd from this connection */
+            } else {
+                fd = newfd;
+            }
+        }else{
+            warn("Unknown control message on unix domain socket.");
+        }
+        iter++;
+    }
+
+    return fd;
+}
 
 static void receive_data(int fd, void *buf_)
 {
@@ -75,13 +148,30 @@ static void receive_data(int fd, void *buf_)
     ExtlFn fn;
     int i, n;
     bool success=FALSE;
+    int idx=buf-bufs;
+
+    if(buf->stdout==NULL){ /* no fd received yet, must be the very beginning */
+        int stdout_fd=unix_recv_fd(fd);
+        if(stdout_fd==-2)
+            goto closefd;
+
+        if(stdout_fd==-1) {
+            if(errno==EWOULDBLOCK || errno==EAGAIN)
+                return; /* try again later */
+            warn("No file descriptor received from notionflux, closing.");
+            goto closefd;
+        }
+        if((buf->stdout=fdopen(stdout_fd, "w"))==NULL) {
+            warn("fdopen() failed on fd from notionflux");
+            goto closefd;
+        }
+    }
 
     n=read(fd, buf->data+buf->ndata, MAX_DATA-buf->ndata);
 
     if(n==0){
         warn("Connection closed prematurely.");
-        close_conn(buf);
-        return;
+        goto closefd;
     }
 
     if(n<0){
@@ -101,17 +191,18 @@ static void receive_data(int fd, void *buf_)
 
     if(!end && buf->ndata+n==MAX_DATA){
         writes(fd, "Error: too much data\n");
-        close_conn(buf);
-        return;
+        goto closefd;
     }
 
     if(!end)
         return;
 
     errorlog_begin(&el);
+
+    if(!extl_lookup_global_value(&tostringfn, 'f', "mod_notionflux", "run_lua", NULL)) return;
     if(extl_loadstring(buf->data, &fn)){
         char *retstr=NULL;
-        if(extl_call(tostringfn, "f", "s", fn, &retstr)){
+        if(extl_call(tostringfn, "fi", "s", fn, idx, &retstr)){
             success=TRUE;
             writes(fd, "S");
             writes(fd, retstr);
@@ -127,9 +218,21 @@ static void receive_data(int fd, void *buf_)
     }
     errorlog_deinit(&el);
 
+closefd:
     close_conn(buf);
+    return;
 }
 
+/**EXTL_DOC
+ * Write \var{str} to the output file descriptor associated with client \var{idx}
+ */
+EXTL_EXPORT
+bool mod_notionflux_xwrite(int idx, const char *str)
+{
+    if (idx<0 || idx>=MAX_SERVED || bufs[idx].stdout==NULL)
+        return FALSE;
+    return fputs(str, bufs[idx].stdout)!=EOF;
+}
 
 static void connection_attempt(int lfd, void *UNUSED(data))
 {
@@ -290,14 +393,15 @@ bool mod_notionflux_init()
     int i;
     WRootWin *rw;
 
+    if (!mod_notionflux_register_exports())
+        return FALSE;
+
     for(i=0; i<MAX_SERVED; i++){
         bufs[i].fd=-1;
+        bufs[i].stdout=NULL;
         bufs[i].data=NULL;
         bufs[i].ndata=0;
     }
-
-    if(!extl_lookup_global_value(&tostringfn, 'f', "mod_notionflux", "run_lua", NULL))
-        return FALSE;
 
     if (!start_listening())
         goto err_listening;

--- a/mod_notionflux/mod_notionflux.lua
+++ b/mod_notionflux/mod_notionflux.lua
@@ -1,0 +1,57 @@
+if package.loaded["mod_notionflux"] then return end
+
+local mod_notionflux={}
+
+-- this function is used by C to collect print() calls into a buffer
+function mod_notionflux.output_collector()
+    -- collecting strings in a table and using table.concat produces less garbage
+    local out={}
+
+    local function print(...)
+        for i,v in ipairs{...} do
+            if i>1 then
+                table.insert(out, "\t")
+            end
+            local s=tostring(v)
+            if type(s) ~= "string" then
+                error "'tostring' must return a string to 'print'"
+            end
+            table.insert(out, s)
+        end
+        table.insert(out, "\n")
+    end
+
+    local function finish()
+        local ret=table.concat(out)
+        out=nil
+        return ret
+    end
+
+    return print, finish
+end
+
+-- takes input from mod_notionflux socket as a function (as produced by
+-- loadstring), calls it with modified _G.print, returns a string containing all
+-- printed text and the return value
+function mod_notionflux.run_lua(fn)
+    local newprint, finish = mod_notionflux.output_collector()
+    local oldprint=_G.print
+    _G.print=newprint
+    local ok, res=pcall(fn)
+    _G.print=oldprint
+    local out=finish() -- swallowed in case of error
+    if not ok then error(res) end
+
+    -- format a string result using %q
+    res = type(res) == "string" and string.format("%q", res) or tostring(res)
+    out = #out>0 and out.."\n" or ""
+    return out..res
+end
+
+_G["mod_notionflux"]=mod_notionflux
+if not ioncore.load_module("mod_notionflux") then
+    _G["mod_notionflux"]=nil
+    return
+end
+
+package.loaded["mod_notionflux"]=true

--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -415,8 +415,6 @@ char const *make_dofile_exp(char const *path, struct buf *buf)
 
 	/* quote the string for lua */
 	for (char *p=rpath; *p!='\0' && buf_pos(buf) < buf->size; p++){
-		/* this switch statement is not strictly required because nobody
-		 * is going to see the string */
 		switch (*p) {
 		case '\r': buf_append(buf, "\\r"); continue;
 		case '\n': buf_append(buf, "\\n"); continue;
@@ -424,6 +422,7 @@ char const *make_dofile_exp(char const *path, struct buf *buf)
 		case '\'': buf_append(buf, "\\'"); continue;
 		case '\f': buf_append(buf, "\\f"); continue;
 		case '\v': buf_append(buf, "\\v"); continue;
+		case '\\': buf_append(buf, "\\\\"); continue;
 		}
 
 		if (*p >= ' ' && *p <= '~') { /* printable 7-bit ASCII */


### PR DESCRIPTION
This patchset implements a print() function for use in mod_notionflux.

This can theoretically be merged, but the question is whether instead of collecting print() output and displaying it at the very end (and losing it in case of an error), passing a file descriptor (e.g. stdout) from notionflux to mod_notionflux over the unix socket is a better solution.