### PR TITLE
Support submaps (binding and entering) when no kpress binding is defined

### DIFF
--- a/ioncore/binding.c
+++ b/ioncore/binding.c
@@ -390,7 +390,7 @@ static void grab_key(Display *display, uint keycode, uint ksb,
 
 void binding_grab_on(const WBinding *binding, Window win)
 {
-    if(binding->act==BINDING_KEYPRESS && binding->kcb!=0){
+    if((binding->act==BINDING_KEYPRESS || binding->act==BINDING_SUBMAP) && binding->kcb!=0){
 #ifndef CF_HACK_IGNORE_EVIL_LOCKS
         grab_key(ioncore_g.dpy, binding->kcb, binding->ksb, binding->state,
                  win, True, GrabModeAsync, GrabModeAsync);
@@ -424,7 +424,7 @@ void binding_grab_on(const WBinding *binding, Window win)
 
 void binding_ungrab_on(const WBinding *binding, Window win)
 {
-    if(binding->act==BINDING_KEYPRESS){
+    if(binding->act==BINDING_KEYPRESS || binding->act==BINDING_SUBMAP){
 #ifndef CF_HACK_IGNORE_EVIL_LOCKS
         XUngrabKey(ioncore_g.dpy, binding->kcb, binding->state, win);
 #else
@@ -515,7 +515,7 @@ static WBinding *do_bindmap_lookup_binding(WBindmap *bindmap,
 
         if(binding==NULL){
             tmp.state=state;
-            tmp.ksb=(act==BINDING_KEYPRESS ? AnyKey : AnyButton);
+            tmp.ksb=((act==BINDING_KEYPRESS || act==BINDING_SUBMAP) ? AnyKey : AnyButton);
 
             binding=search_binding_ksb(bindmap, &tmp);
 

--- a/ioncore/key.c
+++ b/ioncore/key.c
@@ -244,12 +244,9 @@ static bool do_key(WRegion *reg, XKeyEvent *ev)
     }
 
     has_submap = submap_defined(oreg, ev);
-    if(has_submap){
-        if(add_sub(oreg, ev->keycode, ev->state))
-            grab_needed = TRUE;
-        else
-            clear_subs(oreg);
-    }else
+    if(has_submap && add_sub(oreg, ev->keycode, ev->state))
+        grab_needed = TRUE;
+    else
         clear_subs(oreg);
 
     if(binding!=NULL){

--- a/ioncore/key.c
+++ b/ioncore/key.c
@@ -249,22 +249,20 @@ static bool do_key(WRegion *reg, XKeyEvent *ev)
             grab_needed = TRUE;
         else
             clear_subs(oreg);
-    }
+    }else
+        clear_subs(oreg);
 
     if(binding!=NULL){
         if(binding_owner!=NULL && binding->func!=extl_fn_none()){
             WRegion *mgd=region_managed_within(binding_owner, subreg);
             bool subs=(oreg->submapstat!=NULL);
 
-            if(!has_submap)
-                clear_subs(oreg);
-
             if(grabbed)
                 XUngrabKeyboard(ioncore_g.dpy, CurrentTime);
 
             current_kcb=ev->keycode;
             current_state=ev->state;
-            current_submap=subs;
+            current_submap=oreg->submapstat!=NULL;
 
             /* TODO: having to pass both mgd and subreg for some handlers
              * to work is ugly and complex.
@@ -276,8 +274,6 @@ static bool do_key(WRegion *reg, XKeyEvent *ev)
             if(ev->state!=0 && !subs && binding->wait)
                 waitrelease(oreg);
         }
-    }else if(oreg->submapstat!=NULL){
-        clear_subs(oreg);
     }else if(OBJ_IS(oreg, WWindow)){
         insstr((WWindow*)oreg, ev);
     }


### PR DESCRIPTION
Fixes #128