### PR TITLE
frame-draw: draw region display name during FRAME_SHOW_NUMBERS

### DIFF
--- a/ioncore/frame-draw.c
+++ b/ioncore/frame-draw.c
@@ -407,7 +407,8 @@ void frame_recalc_bar(WFrame *frame)
         if(textw>0){
             if(frame->flags&FRAME_SHOW_NUMBERS){
                 char *s=NULL;
-                libtu_asprintf(&s, "[%d]", i+1);
+                const char *name=region_displayname(sub);
+                libtu_asprintf(&s, "[%d] %s", i+1, name);
                 if(s!=NULL){
                     title=grbrush_make_label(frame->bar_brush, s, textw);
                     free(s);


### PR DESCRIPTION
Very opionated change that will get back old behaviour of showing tab numbers along with tab client names.

During the day I often end up with a lot of "tabs" and find this concept very useful. Also I have a memory of goldfish, so I'm instantly forgetting which window was where after hitting the hotkey. :-) This should help people like me.

I can also introduce a configuration variable to control this, if there is some opposition of priting this information. Although in that case I'd like to introduce not just a lever with on\off but a whole format string so user can decide what exact format print here.