### PR TITLE
Global safe tempdir

### DIFF
--- a/ioncore/Makefile
+++ b/ioncore/Makefile
@@ -25,7 +25,7 @@ SOURCES=binding.c conf-bindings.c cursor.c event.c exec.c focus.c         \
         stacking.c group.c grouppholder.c group-cw.c navi.c		  \
         group-ws.c float-placement.c groupedpholder.c framedpholder.c	  \
         return.c detach.c screen-notify.c frame-tabs-recalc.c profiling.c \
-        log.c
+        log.c tempdir.c
 
 LUA_SOURCES=\
 	ioncore_ext.lua ioncore_luaext.lua ioncore_bindings.lua \

--- a/ioncore/ioncore.c
+++ b/ioncore/ioncore.c
@@ -61,7 +61,7 @@
 #include "exec.h"
 #include "screen-notify.h"
 #include "log.h"
-
+#include "tempdir.h"
 
 #include "../version.h"
 #include "exports.h"
@@ -663,6 +663,8 @@ void ioncore_deinit()
     stringstore_deinit();
 
     mainloop_unregister_input_fd(ioncore_g.conn);
+
+    ioncore_tempdir_cleanup();
 
     dpy=ioncore_g.dpy;
     ioncore_g.dpy=NULL;

--- a/ioncore/tempdir.c
+++ b/ioncore/tempdir.c
@@ -20,8 +20,8 @@
 #include "tempdir.h"
 #include "log.h"
 
-char template[]="/tmp/notion.XXXXXX\0\0";
-char const *tempdir=NULL;
+static char template[]="/tmp/notion.XXXXXX\0\0";
+static char const *tempdir=NULL;
 
 /*EXTL_DOC
  * Returns the global temporary directory for this notion instance with a

--- a/ioncore/tempdir.c
+++ b/ioncore/tempdir.c
@@ -1,0 +1,74 @@
+/*
+ * notion/ioncore/tempdir.c
+ *
+ * Copyright (c) 2019 Moritz Wilhelmy
+ *
+ * See the included file LICENSE for details.
+ */
+
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* mkdtemp(3) */
+
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <dirent.h>
+#include <stddef.h>
+
+#include "tempdir.h"
+#include "log.h"
+
+char template[]="/tmp/notion.XXXXXX\0\0";
+char const *tempdir=NULL;
+
+/*EXTL_DOC
+ * Returns the global temporary directory for this notion instance with a
+ * trailing slash. The directory is created in case it does not exist.
+ * The directory will be non-recursively deleted on teardown, therefore no
+ * subdirectories should be created.
+ */
+EXTL_SAFE
+EXTL_EXPORT
+const char *ioncore_tempdir()
+{
+    if(tempdir)
+        return tempdir;
+
+    tempdir=mkdtemp(template); /* points to template */
+    if(!tempdir){
+        LOG(ERROR, GENERAL, "Error creating temporary directory: %s.",
+            strerror(errno));
+        return NULL;
+    }
+
+    template[strlen(tempdir)]='/';
+    return tempdir;
+}
+
+void ioncore_tempdir_cleanup(void)
+{
+    DIR *dir;
+    struct dirent *dent;
+    char fname[sizeof(template)+NAME_MAX];
+    size_t const offs=strlen(tempdir);
+
+    if(!tempdir)
+        return;
+
+    dir=opendir(tempdir);
+    if(!dir){
+        LOG(ERROR, GENERAL, "Error opening temporary directory: %s.",
+            strerror(errno));
+        return;
+    }
+
+    strcpy(fname, tempdir);
+    while((dent=readdir(dir))){
+        strcpy(fname+offs, dent->d_name);
+        unlink(fname);
+    }
+    rmdir(tempdir);
+    tempdir=NULL;
+}

--- a/ioncore/tempdir.h
+++ b/ioncore/tempdir.h
@@ -1,0 +1,17 @@
+/*
+ * notion/ioncore/tempdir.h
+ *
+ * Copyright (c) 2019 Moritz Wilhelmy
+ *
+ * See the included file LICENSE for details.
+ */
+
+#ifndef NOTION_IONCORE_TEMPDIR_H
+#define NOTION_IONCORE_TEMPDIR_H
+
+#include <libextl/extl.h>
+
+extern const char *ioncore_tempdir();
+extern void ioncore_tempdir_cleanup(void);
+
+#endif /* NOTION_IONCORE_TEMPDIR_H */

--- a/mod_notionflux/notionflux.h
+++ b/mod_notionflux/notionflux.h
@@ -16,6 +16,5 @@
 #define MAX_SERVED 8
 #define CHUNK 1024
 #define MAX_DATA (1024*4)
-#define SOCK_MAX (108-1)
 
 #endif


### PR DESCRIPTION
Adds a safe temporary directory created using mkdtemp(3), makes it accessible to Lua, uses it to put the mod_notionflux socket inside and deletes everything on exit. 