### PR TITLE
tempdir: Avoid strlen(NULL) in case the tempdir was never created

### DIFF
--- a/ioncore/tempdir.c
+++ b/ioncore/tempdir.c
@@ -52,7 +52,7 @@ void ioncore_tempdir_cleanup(void)
     DIR *dir;
     struct dirent *dent;
     char fname[sizeof(template)+NAME_MAX];
-    size_t const offs=strlen(tempdir);
+    size_t const offs=strlen(template);
 
     if(!tempdir)
         return;

--- a/ioncore/tempdir.c
+++ b/ioncore/tempdir.c
@@ -69,6 +69,7 @@ void ioncore_tempdir_cleanup(void)
         strcpy(fname+offs, dent->d_name);
         unlink(fname);
     }
+    closedir(dir);
     rmdir(tempdir);
     tempdir=NULL;
 }


### PR DESCRIPTION
Foiled by trying to keep it C89 compliant ;(