### PR TITLE
Cleanup: quiet '-Wextra-semi-stmt' clang warning

### DIFF
--- a/de/brush.c
+++ b/de/brush.c
@@ -29,7 +29,9 @@
 #define MATCHES(S, A) (gr_stylespec_score(&(S), A)>0)
 
 #define ENSURE_INITSPEC(S, NM) \
-    if((S).attrs==NULL) gr_stylespec_load(&(S), NM);
+    if((S).attrs==NULL){ \
+        gr_stylespec_load(&(S), NM); \
+    } ((void)0)
 
 
 static GrStyleSpec tabframe_spec=GR_STYLESPEC_INIT;
@@ -293,6 +295,3 @@ IMPLCLASS(DEBrush, GrBrush, debrush_deinit, debrush_dynfuntab);
 
 
 /*}}}*/
-
-
-

--- a/de/font.h
+++ b/de/font.h
@@ -23,7 +23,7 @@ INTRSTRUCT(DEFont);
 #include "style.h"
 
 #define DE_RESET_FONT_EXTENTS(FNTE) \
-   {(FNTE)->max_height=0; (FNTE)->max_width=0; (FNTE)->baseline=0;}
+   {(FNTE)->max_height=0; (FNTE)->max_width=0; (FNTE)->baseline=0;} ((void)0)
 
 DECLSTRUCT(DEFont){
     char *pattern;

--- a/ioncore/bindmaps.c
+++ b/ioncore/bindmaps.c
@@ -52,7 +52,7 @@ static StringIntMap frame_areas[]={
     if(ioncore_ ## X ## _bindmap!=NULL){                    \
         ioncore_free_bindmap(Y, ioncore_ ## X ## _bindmap); \
         ioncore_ ## X ## _bindmap=NULL;                     \
-    }
+    } ((void)0)
 
 void ioncore_deinit_bindmaps()
 {
@@ -76,8 +76,9 @@ void ioncore_deinit_bindmaps()
 
 #define DO_ALLOC(X, Y, Z)                                  \
     ioncore_ ## X ## _bindmap=ioncore_alloc_bindmap(Y, Z); \
-    if(ioncore_ ## X ## _bindmap==NULL)                    \
-        return FALSE;
+    if(ioncore_ ## X ## _bindmap==NULL){                   \
+        return FALSE;                                      \
+    } ((void)0)
 
 bool ioncore_init_bindmaps()
 {
@@ -249,4 +250,3 @@ WBindmap *region_add_cycle_bindmap(WRegion *reg, uint kcb, uint state,
 
     return bindmap;
 }
-

--- a/ioncore/clientwin.c
+++ b/ioncore/clientwin.c
@@ -106,7 +106,7 @@ void clientwin_get_protocols(WClientWin *cwin)
         }                                            \
         extl_unref_table(tab2);                      \
     }                                                \
-}
+} ((void)0)
 
 
 static void clientwin_get_winprops(WClientWin *cwin)

--- a/ioncore/event.c
+++ b/ioncore/event.c
@@ -66,7 +66,7 @@ static void check_signals()
 
 /*{{{ Timestamp stuff */
 
-#define CHKEV(E, T) case E: tm=((T*)ev)->time; break;
+#define CHKEV(E, T) case E: tm=((T*)ev)->time; break
 #define CLOCK_SKEW_MS 30000
 
 static Time last_timestamp=CurrentTime;
@@ -248,4 +248,3 @@ void ioncore_mainloop()
 
 
 /*}}}*/
-

--- a/ioncore/ioncore.c
+++ b/ioncore/ioncore.c
@@ -323,7 +323,8 @@ static bool register_classes()
 
 #define INITSTR(NM)                             \
     ioncore_g.notifies.NM=stringstore_alloc(#NM); \
-    if(ioncore_g.notifies.NM==STRINGID_NONE) return FALSE;
+    if(ioncore_g.notifies.NM==STRINGID_NONE) return FALSE; \
+    ((void)0)
 
 static bool init_global()
 {
@@ -726,4 +727,3 @@ const char *ioncore_aboutmsg()
 
 
 /*}}}*/
-

--- a/ioncore/property.c
+++ b/ioncore/property.c
@@ -294,7 +294,7 @@ char *ioncore_x_get_atom_name(int atom)
     {                                                         \
         TYPE *d=(TYPE*)p;                                     \
         for(i=0; i<n; i++) extl_table_seti_i(tab, i+1, d[i]); \
-    }
+    } ((void)0)
 
 
 /*EXTL_DOC
@@ -347,7 +347,7 @@ ExtlTab ioncore_x_get_window_property(int win, int atom, int atom_type,
             d[i]=tmp;                                      \
         }                                                  \
         p=(uchar*)d;                                       \
-    }
+    } ((void)0)
 
 
 static bool get_mode(const char *mode, int *m)

--- a/ioncore/resize.c
+++ b/ioncore/resize.c
@@ -108,7 +108,7 @@ static WInfoWin *setup_moveres_display(WWindow *parent, int cx, int cy)
     fp.g.w+=chars_for_num(REGION_GEOM(parent).h);
     fp.g.w*=max_width(INFOWIN_BRUSH(infowin), "0123456789x+");
     fp.g.w+=bdw.left+bdw.right;
-    fp.g.h=fnte.max_height+bdw.top+bdw.bottom;;
+    fp.g.h=fnte.max_height+bdw.top+bdw.bottom;
 
     fp.g.x=cx-fp.g.w/2;
     fp.g.y=cy-fp.g.h/2;
@@ -898,4 +898,3 @@ void region_absolute_geom_to_parent(WRegion *reg, const WRectangle *rgeom,
 }
 
 /*}}}*/
-

--- a/libextl/private.h
+++ b/libextl/private.h
@@ -83,12 +83,14 @@ typedef Watch ExtlProxy;
 #define EXTL_BEGIN_PROXY_OBJ(PROXY, OBJ)       \
     watch_init(PROXY);                         \
     watch_setup(PROXY, OBJ, NULL);             \
-    (OBJ)->flags|=OBJ_EXTL_CACHED;
+    (OBJ)->flags|=OBJ_EXTL_CACHED;             \
+    ((void)0)
 
 #define EXTL_END_PROXY_OBJ(PROXY, OBJ) \
     assert((PROXY)->obj==OBJ);         \
     watch_reset(PROXY);                \
-    (OBJ)->flags&=~OBJ_EXTL_CACHED;
+    (OBJ)->flags&=~OBJ_EXTL_CACHED;    \
+    ((void)0)
 
 #define EXTL_DESTROY_OWNED_OBJ(OBJ) destroy_obj(OBJ)
 

--- a/libmainloop/signal.c
+++ b/libmainloop/signal.c
@@ -431,7 +431,7 @@ static void ignore_handler(int UNUSED(signal_num))
 #endif
 
 #define IFTRAP(X) if(sigismember(which, X))
-#define DEADLY(X) IFTRAP(X) signal(X, deadly_signal_handler);
+#define DEADLY(X) IFTRAP(X) signal(X, deadly_signal_handler)
 #define IGNORE(X) IFTRAP(X) signal(X, SIG_IGN)
 
 void mainloop_trap_signals(const sigset_t *which)
@@ -508,4 +508,3 @@ void mainloop_trap_signals(const sigset_t *which)
 
 
 /*}}}*/
-

--- a/libtu/dlist.h
+++ b/libtu/dlist.h
@@ -23,7 +23,7 @@
         (ITEM)->PREV=(LIST)->PREV;        \
         (ITEM)->PREV->NEXT=(ITEM);        \
         (LIST)->PREV=(ITEM);              \
-    }
+    } ((void)0)
 
 
 #define LINK_ITEM_FIRST(LIST, ITEM, NEXT, PREV) \
@@ -34,7 +34,8 @@
         (ITEM)->PREV=(LIST)->PREV;              \
         (LIST)->PREV=(ITEM);                    \
     }                                           \
-    (LIST)=(ITEM);
+    (LIST)=(ITEM);                              \
+    ((void)0)
 
 
 #define LINK_ITEM_LAST LINK_ITEM
@@ -47,7 +48,8 @@
     if((BEFORE)==(LIST))                                 \
         (LIST)=(ITEM);                                   \
     else                                                 \
-        (ITEM)->PREV->NEXT=(ITEM)
+        (ITEM)->PREV->NEXT=(ITEM);                       \
+    ((void)0)
 
 
 #define LINK_ITEM_AFTER(LIST, AFTER, ITEM, NEXT, PREV) \
@@ -57,7 +59,8 @@
     if((ITEM)->NEXT==NULL)                             \
         (LIST)->PREV=(ITEM);                           \
     else                                               \
-        (ITEM)->NEXT->PREV=ITEM;
+        (ITEM)->NEXT->PREV=ITEM;                       \
+    ((void)0)
 
 
 #define UNLINK_ITEM(LIST, ITEM, NEXT, PREV)  \
@@ -75,7 +78,8 @@
         }                                    \
     }                                        \
     (ITEM)->NEXT=NULL;                       \
-    (ITEM)->PREV=NULL;
+    (ITEM)->PREV=NULL;                       \
+    ((void)0)
 
 
 /*}}}*/

--- a/libtu/objp.h
+++ b/libtu/objp.h
@@ -41,12 +41,14 @@ DECLSTRUCT(ClassDescr){
 #define CREATEOBJ_IMPL(OBJ, LOWOBJ, INIT_ARGS)                     \
     OBJ *p;  p=ALLOC(OBJ); if(p==NULL){ warn_err(); return NULL; } \
     OBJ_INIT(p, OBJ);                                             \
-    if(!LOWOBJ ## _init INIT_ARGS) { free((void*)p); return NULL; } return p
+    if(!LOWOBJ ## _init INIT_ARGS) { free((void*)p); return NULL; } return p; \
+    ((void)0)
 
 #define SIMPLECREATEOBJ_IMPL(OBJ, LOWOBJ)                          \
     OBJ *p;  p=ALLOC(OBJ); if(p==NULL){ warn_err(); return NULL; } \
-    OBJ_INIT(p, OBJ);                                             \
-    return p;
+    OBJ_INIT(p, OBJ);                                              \
+    return p;                                                      \
+    ((void)0)
 
 #define END_DYNFUNTAB {NULL, NULL}
 
@@ -56,16 +58,18 @@ extern bool has_dynfun(const Obj *obj, DynFun *func);
 
 #define CALL_DYN(FUNC, OBJ, ARGS)                                \
     bool funnotfound;                                            \
-    lookup_dynfun((Obj*)OBJ, (DynFun*)FUNC, &funnotfound) ARGS;
+    lookup_dynfun((Obj*)OBJ, (DynFun*)FUNC, &funnotfound) ARGS;  \
+    ((void)0)
 
 #define CALL_DYN_RET(RETV, RET, FUNC, OBJ, ARGS)                 \
     typedef RET ThisDynFun();                                    \
     bool funnotfound;                                            \
     ThisDynFun *funtmp;                                          \
-    funtmp=(ThisDynFun*)lookup_dynfun((Obj*)OBJ, (DynFun*)FUNC, \
+    funtmp=(ThisDynFun*)lookup_dynfun((Obj*)OBJ, (DynFun*)FUNC,  \
                                       &funnotfound);             \
-    if(!funnotfound)                                             \
-        RETV=funtmp ARGS;
+    if(!funnotfound){                                            \
+        RETV=funtmp ARGS;                                        \
+    } ((void)0)
 
 #define HAS_DYN(OBJ, FUNC) has_dynfun((Obj*)OBJ, (DynFun*)FUNC)
 

--- a/libtu/output.c
+++ b/libtu/output.c
@@ -211,8 +211,13 @@ void warn_err_obj_line(const char *obj, int line)
  */
 
 #define CALL_V_RET(NAME, ARGS) \
-    char *ret; va_list args; va_start(args, p); ret=NAME ARGS; \
-    va_end(args); return ret;
+    char *ret; \
+    va_list args; \
+    va_start(args, p); \
+    ret=NAME ARGS; \
+    va_end(args); \
+    return ret; \
+    ((void)0)
 
 
 char* errmsg(const char *p, ...)

--- a/libtu/rb.c
+++ b/libtu/rb.c
@@ -55,7 +55,7 @@ static void rb_iprint_tree(Rb_node t, int level);
 #define setroot(n) n->s.root = 1
 #define setint(n) n->s.internal = 1
 #define setext(n) n->s.internal = 0
-#define setnormal(n) { n->s.root = 0; n ->s.head = 0; }
+#define setnormal(n) { n->s.root = 0; n ->s.head = 0; } ((void)0)
 #define sibling(n) ((isleft(n)) ? n->p.parent->c.child.right \
                                 : n->p.parent->c.child.left)
 
@@ -85,7 +85,7 @@ static void delete_item(Rb_node item)		/* Deletes an arbitrary iterm */
   setext(new);\
   setblack(new);\
   setnormal(new);\
-}
+} ((void)0)
 
 static void mk_new_int(Rb_node l, Rb_node r, Rb_node p, int il)
 {
@@ -621,5 +621,3 @@ Rb_node rb_insertp(Rb_node tree, const void *key, void *val)
 {
   return rb_insertg(tree, key, val, ptrcmp);
 }
-
-

--- a/libtu/tokenizer.c
+++ b/libtu/tokenizer.c
@@ -50,11 +50,11 @@ static const char *errors[]={
 
 #define STRBLEN 32
 
-#define STRING_DECL(X) int err=0; char* X=NULL; char X##_tmp[STRBLEN]; int X##_tmpl=0
-#define STRING_DECL_P(X, P) int err=0; char* X=NULL; char X##_tmp[STRBLEN]=P; int X##_tmpl=sizeof(P)-1
-#define STRING_APPEND(X, C) {if(!_string_append(&X, X##_tmp, &X##_tmpl, c)) err=-ENOMEM;}
+#define STRING_DECL(X) int err=0; char* X=NULL; char X##_tmp[STRBLEN]; int X##_tmpl=0; ((void)0)
+#define STRING_DECL_P(X, P) int err=0; char* X=NULL; char X##_tmp[STRBLEN]=P; int X##_tmpl=sizeof(P)-1; ((void)0)
+#define STRING_APPEND(X, C) {if(!_string_append(&X, X##_tmp, &X##_tmpl, c)) err=-ENOMEM;} ((void)0)
 #define STRING_FREE(X) if(X!=NULL) free(X)
-#define STRING_FINISH(X) {if(err!=0) return err; if(!_string_finish(&X, X##_tmp, X##_tmpl)) err=-ENOMEM;}
+#define STRING_FINISH(X) {if(err!=0) return err; if(!_string_finish(&X, X##_tmp, X##_tmpl)) err=-ENOMEM;} ((void)0)
 
 
 static bool _string_append(char **p, char *tmp, int *tmplen, char c)
@@ -955,4 +955,3 @@ void tok_init(Token *tok)
 
     memcpy(tok, &dummy, sizeof(*tok));
 }
-

--- a/libtu/tokenizer.h
+++ b/libtu/tokenizer.h
@@ -14,14 +14,14 @@
 #include "types.h"
 
 
-#define TOK_SET_BOOL(TOK, VAL)         {(TOK)->type=TOK_BOOL; (TOK)->u.bval=VAL;}
-#define TOK_SET_LONG(TOK, VAL)         {(TOK)->type=TOK_LONG; (TOK)->u.lval=VAL;}
-#define TOK_SET_DOUBLE(TOK, VAL)     {(TOK)->type=TOK_DOUBLE; (TOK)->u.dval=VAL;}
-#define TOK_SET_CHAR(TOK, VAL)         {(TOK)->type=TOK_CHAR; (TOK)->u.cval=VAL;}
-#define TOK_SET_STRING(TOK, VAL)     {(TOK)->type=TOK_STRING; (TOK)->u.sval=VAL;}
-#define TOK_SET_IDENT(TOK, VAL)     {(TOK)->type=TOK_IDENT; (TOK)->u.sval=VAL;}
-#define TOK_SET_COMMENT(TOK, VAL)     {(TOK)->type=TOK_COMMENT; (TOK)->u.sval=VAL;}
-#define TOK_SET_OP(TOK, VAL)         {(TOK)->type=TOK_OP; (TOK)->u.opval=VAL;}
+#define TOK_SET_BOOL(TOK, VAL)         {(TOK)->type=TOK_BOOL; (TOK)->u.bval=VAL;} ((void)0)
+#define TOK_SET_LONG(TOK, VAL)         {(TOK)->type=TOK_LONG; (TOK)->u.lval=VAL;} ((void)0)
+#define TOK_SET_DOUBLE(TOK, VAL)     {(TOK)->type=TOK_DOUBLE; (TOK)->u.dval=VAL;} ((void)0)
+#define TOK_SET_CHAR(TOK, VAL)         {(TOK)->type=TOK_CHAR; (TOK)->u.cval=VAL;} ((void)0)
+#define TOK_SET_STRING(TOK, VAL)     {(TOK)->type=TOK_STRING; (TOK)->u.sval=VAL;} ((void)0)
+#define TOK_SET_IDENT(TOK, VAL)     {(TOK)->type=TOK_IDENT; (TOK)->u.sval=VAL;} ((void)0)
+#define TOK_SET_COMMENT(TOK, VAL)     {(TOK)->type=TOK_COMMENT; (TOK)->u.sval=VAL;} ((void)0)
+#define TOK_SET_OP(TOK, VAL)         {(TOK)->type=TOK_OP; (TOK)->u.opval=VAL;} ((void)0)
 
 #define TOK_TYPE(TOK)                ((TOK)->type)
 #define TOK_BOOL_VAL(TOK)            ((TOK)->u.bval)

--- a/mod_query/wedln.c
+++ b/mod_query/wedln.c
@@ -79,7 +79,7 @@ static void dispu(const char* s, int l)
         tx+=wedln_draw_strsect(wedln, geom->x+tx, ty,       \
                                str, LEN, GR_ATTR(A));       \
         str+=LEN; len-=LEN;                                 \
-    }
+    } ((void)0)
 
 
 GR_DEFATTR(active);

--- a/mod_tiling/main.c
+++ b/mod_tiling/main.c
@@ -114,7 +114,8 @@ static bool register_regions()
 
 #define INIT_HOOK_(NM)                             \
     NM=mainloop_register_hook(#NM, create_hook()); \
-    if(NM==NULL) return FALSE;
+    if(NM==NULL) return FALSE; \
+    ((void)0)
 
 
 static bool init_hooks()
@@ -151,4 +152,3 @@ err:
 
 
 /*}}}*/
-

--- a/mod_xkbevents/mod_xkbevents.c
+++ b/mod_xkbevents/mod_xkbevents.c
@@ -237,7 +237,8 @@ void deinit_hooks()
 
 #define INIT_HOOK_(NM)                             \
     NM=mainloop_register_hook(#NM, create_hook()); \
-    if(NM==NULL) return FALSE;
+    if(NM==NULL) return FALSE; \
+    ((void)0)
 
 static bool init_hooks()
 {


### PR DESCRIPTION
Ensures macros end with a semi-colon,
avoids accidents with macro use.