### PR TITLE
Fix high-dpi look, make sure it is loaded depending on width

### DIFF
--- a/de/font.c
+++ b/de/font.c
@@ -87,6 +87,7 @@ DEFont *de_load_font(const char *fontname)
 #ifdef HAVE_X11_BMF
 #ifdef HAVE_X11_XFT
 bitmap_font:
+    if(font==NULL){
 #endif
 
     if(ioncore_g.use_mb){
@@ -116,6 +117,9 @@ bitmap_font:
         }
         return NULL;
     }
+#ifdef HAVE_X11_XFT
+    }
+#endif /* HAVE_X11_XFT */
 #endif /* HAVE_X11_BMF */
 
     fnt=ALLOC(DEFont);

--- a/etc/look_newviolet_hidpi.lua
+++ b/etc/look_newviolet_hidpi.lua
@@ -22,13 +22,13 @@ de.defstyle("*", {
     border_style = "elevated",
     border_sides = "tb",
 
-    font = "xft:Source Code Sans:size=16",
+    font = "xft:Source Sans Pro:size=20",
     text_align = "center",
 })
 
 
 de.defstyle("tab", {
-    font = "xft:Source Code Sans:size=16",
+    font = "xft:Source Sans Pro:size=20",
 
     de.substyle("active-selected", {
         highlight_colour = "#aaaacc",

--- a/ioncore/ioncore.c
+++ b/ioncore/ioncore.c
@@ -611,12 +611,12 @@ bool ioncore_startup(const char *display, const char *cfgfile,
     if(!ioncore_init_x(display, stflags))
         return FALSE;
 
-    gr_read_config();
-
     if(!extl_read_config("ioncore_ext", NULL, TRUE))
         return FALSE;
 
     ioncore_read_main_config(cfgfile);
+
+    gr_read_config();
 
     if(!ioncore_init_layout())
         return FALSE;


### PR DESCRIPTION
To auto-detect high-dpi screens, mod_xinerama should be loaded before
loading the theme