### PR TITLE
Change query_runfile (View) to use xdg-open by default

### DIFF
--- a/etc/cfg_bindings.lua
+++ b/etc/cfg_bindings.lua
@@ -190,11 +190,11 @@ defbindings("WMPlex.toplevel", {
 
     bdoc("Query for file to edit.", "edit"),
     kpress(META.."F5",
-           "mod_query.query_editfile(_, 'run-mailcap --action=edit')"),
+           "mod_query.query_editfile(_, EDIT_COMMAND or 'run-mailcap --action=edit')"),
 
     bdoc("Query for file to view.", "view"),
     kpress(META.."F6",
-           "mod_query.query_runfile(_, 'run-mailcap --action=view')"),
+           "mod_query.query_runfile(_, VIEW_COMMAND or 'xdg-open')"),
 
     bdoc("Query for keybinding.", "qkb"),
     kpress(META.."F7",

--- a/etc/cfg_notion.lua
+++ b/etc/cfg_notion.lua
@@ -19,6 +19,10 @@
 
 -- Terminal emulator.
 --XTERM="xterm"
+-- Edit file command, mod_query.query_editfile
+--EDIT_COMMAND="run-mailcap --action=edit"
+-- View file command, mod_query.query_viewfile
+--VIEW_COMMAND="xdg-open"
 
 -- Some basic settings.
 ioncore.set{

--- a/mod_query/mod_query.lua
+++ b/mod_query/mod_query.lua
@@ -617,12 +617,12 @@ end
 
 --DOC
 -- Asks for a file to be viewed. This script uses
--- \command{run-mailcap --action=view} by default, but you may provide an
+-- \command{xdg-open} by default, but you may provide an
 -- alternative script to use. The default prompt is "View file:" (translated).
 function mod_query.query_runfile(mplex, script, prompt)
     mod_query.query_execfile(mplex,
                              prompt or TR("View file:"),
-                             script or "run-mailcap --action=view")
+                             script or "xdg-open")
 
 end
 


### PR DESCRIPTION
Both Edit/View file can be customized by setting EDIT_COMMAND/VIEW_COMMAND
in etc/cfg_notion.lua

Fix #144