### PR TITLE
Don't override fonts in etc/lookcommon_*

### DIFF
--- a/etc/lookcommon_clean_stdisp.lua
+++ b/etc/lookcommon_clean_stdisp.lua
@@ -6,7 +6,6 @@ de.defstyle("stdisp", {
     text_align = "left",
     background_colour = "#000000",
     foreground_colour = "grey",
-    font="-misc-fixed-medium-r-*-*-13-*-*-*-*-60-*-*",
 
     de.substyle("important", {
         foreground_colour = "green",

--- a/etc/lookcommon_clean_tab.lua
+++ b/etc/lookcommon_clean_tab.lua
@@ -55,6 +55,5 @@ de.defstyle("tab-menuentry", {
 })
 
 de.defstyle("tab-menuentry-big", {
-    font = "-*-helvetica-medium-r-normal-*-17-*-*-*-*-*-*-*",
     padding_pixels = 7,
 })

--- a/etc/lookcommon_emboss_tab.lua
+++ b/etc/lookcommon_emboss_tab.lua
@@ -57,6 +57,5 @@ de.defstyle("tab-menuentry", {
 })
 
 de.defstyle("tab-menuentry-big", {
-    font = "-*-helvetica-medium-r-normal-*-17-*-*-*-*-*-*-*",
     padding_pixels = 7,
 })


### PR DESCRIPTION
So that they inherit the fonts from the including styles

This makes them more reusable across low- and high-dpi styles,
and causes less surprises with overridden fonts

fixes #200