### PR TITLE
notionflux: complete past colon

### DIFF
--- a/mod_notionflux/notionflux/notionflux.c
+++ b/mod_notionflux/notionflux/notionflux.c
@@ -287,6 +287,8 @@ char *completion_generator(const char *text, int state)
 
 	char *ret;
 	char *lastdot = strrchr(text, '.');
+	char *lastcolon = strrchr(text, ':');
+	lastdot = lastcolon && lastdot < lastcolon ? lastcolon : lastdot;
 	if (!lastdot) {
 		ret = strdup(buf->cur);
 	} else {


### PR DESCRIPTION
```
lua> w=ioncore.current()
nil
lua> w:<Tab>
<list of methods supported by "w" object>
```
Previously, the part before the colon would be eaten on completion attempt.