### PR TITLE
Allow creating the statusbar while brushes aren't available yet

### DIFF
--- a/ioncore/gr.c
+++ b/ioncore/gr.c
@@ -638,7 +638,7 @@ void grbrush_unset_attr(GrBrush *brush, GrAttr attr)
 
 
 /*EXTL_DOC
- * Read drawing engine configuration file \file{draw.lua}.
+ * Read drawing engine configuration file \file{look.lua}, select 'de' engine if none is selected yet.
  */
 EXTL_EXPORT_AS(gr, read_config)
 void gr_read_config()

--- a/ioncore/mplex.c
+++ b/ioncore/mplex.c
@@ -1727,8 +1727,10 @@ WRegion *mplex_set_stdisp_extl(WMPlex *mplex, ExtlTab t)
                                     do_attach_stdisp, NULL,
                                     &data);
 
-        if(stdisp==NULL)
+        if(stdisp==NULL) {
+            warn(TR("Failed to attach stdisp to mplex"));
             return NULL;
+	}
 
     }else if(strcmp(s, "keep")==0){
         stdisp=(WRegion*)(mplex->stdispwatch.obj);
@@ -1738,6 +1740,7 @@ WRegion *mplex_set_stdisp_extl(WMPlex *mplex, ExtlTab t)
     }
 
     if(!mplex_set_stdisp(mplex, stdisp, &din)){
+        warn(TR("Failed to set stdisp."));
         destroy_obj((Obj*)stdisp);
         return NULL;
     }

--- a/ioncore/saveload.c
+++ b/ioncore/saveload.c
@@ -101,7 +101,7 @@ WRegion *create_region_load(WWindow *par, const WFitParams *fp,
     reg=fn(par, fp, tab);
 
     if(reg==NULL){
-	 warn(TR("Creation of \"%s\" returned null", objclass));
+	warn(TR("Creation of \"%s\" returned null"), objclass);
         if(clientwin_was_missing && add_cb!=NULL && ph_cb!=NULL){
             WPHolder *ph=ph_cb();
             if(ph!=NULL){

--- a/ioncore/saveload.c
+++ b/ioncore/saveload.c
@@ -96,13 +96,12 @@ WRegion *create_region_load(WWindow *par, const WFitParams *fp,
         return NULL;
     }
 
-    free(objclass);
-
     clientwin_was_missing=FALSE;
 
     reg=fn(par, fp, tab);
 
     if(reg==NULL){
+	 warn(TR("Creation of \"%s\" returned null", objclass));
         if(clientwin_was_missing && add_cb!=NULL && ph_cb!=NULL){
             WPHolder *ph=ph_cb();
             if(ph!=NULL){
@@ -118,6 +117,8 @@ WRegion *create_region_load(WWindow *par, const WFitParams *fp,
             }
         }
     }
+
+    free(objclass);
 
     ph_cb=NULL;
 

--- a/mod_statusbar/statusbar.c
+++ b/mod_statusbar/statusbar.c
@@ -63,11 +63,6 @@ bool statusbar_init(WStatusBar *p, WWindow *parent, const WFitParams *fp)
 
     statusbar_updategr(p);
 
-    if(p->brush==NULL){
-        window_deinit(&(p->wwin));
-        return FALSE;
-    }
-
     window_select_input(&(p->wwin), IONCORE_EVENTMASK_CWINMGR);
 
     region_register((WRegion*)p);


### PR DESCRIPTION
Should fix #233

Because loading the look was moved to after loading the rest of the config,
so that you can use the modules (e.g. for determining the screen size)
while building the look.

If this turns out to be too harsh, we could separate the loading of the
drawing engine from the loading of the look itself.