### PR TITLE
 Fix window_dialog_float not taken into account

### DIFF
--- a/ioncore/clientwin.c
+++ b/ioncore/clientwin.c
@@ -361,7 +361,7 @@ static bool clientwin_init(WClientWin *cwin, WWindow *par, Window win,
 
     netwm_update_allowed_actions(cwin);
 
-    if(netwm_window_type(cwin)==netwm_window_type_get_atom_dialog()){
+    if(ioncore_g.window_dialog_float && netwm_window_type(cwin)==netwm_window_type_get_atom_dialog()){
         cwin->region.flags|=REGION_PLEASE_FLOAT;
     }
 


### PR DESCRIPTION
 When window_dialog_float is false, which is the case by default, floating dialog windows are enabled anyway. REGION_PLEASE_FLOAT should not be added to region flags in that case.

fixes #61 