### PR TITLE
Remove warning (fixes #252)

### DIFF
--- a/ioncore/saveload.c
+++ b/ioncore/saveload.c
@@ -101,7 +101,6 @@ WRegion *create_region_load(WWindow *par, const WFitParams *fp,
     reg=fn(par, fp, tab);
 
     if(reg==NULL){
-	warn(TR("Creation of \"%s\" returned null"), objclass);
         if(clientwin_was_missing && add_cb!=NULL && ph_cb!=NULL){
             WPHolder *ph=ph_cb();
             if(ph!=NULL){


### PR DESCRIPTION
This warning was added in d5dd2602d, where I assumed it was an error condition
that wouldn't occur in the happy path. That report suggests otherwise, so
let's just remove the warning.