### PR TITLE
docker: make clean before make and allow call from other directory

### DIFF
--- a/utils/docker/Dockerfile.make
+++ b/utils/docker/Dockerfile.make
@@ -39,5 +39,6 @@ RUN apt update && apt install -y lua-posix \
 RUN mkdir /notion
 WORKDIR /notion
 COPY . /notion/
+RUN make clean
 RUN make
 ENTRYPOINT ["/bin/bash"]

--- a/utils/docker/docker-bash.sh
+++ b/utils/docker/docker-bash.sh
@@ -7,6 +7,6 @@ rel_root=$this_rel/../..
 
 notion_root=$(realpath $rel_root)
 
-docker build -f Dockerfile.make -t notion $notion_root
+docker build -f $this_rel/Dockerfile.make -t notion $notion_root
 docker run --rm -it --name notion-test -v /tmp/.X11-unix:/tmp/.X11-unix notion
 

--- a/utils/docker/docker-xephyr.sh
+++ b/utils/docker/docker-xephyr.sh
@@ -7,7 +7,7 @@ rel_root=$this_rel/../..
 
 notion_root=$(realpath $rel_root)
 
-docker build -f Dockerfile.make -t notion $notion_root
-docker build -f Dockerfile.run -t notion-run $notion_root
+docker build -f $this_rel/Dockerfile.make -t notion $notion_root
+docker build -f $this_rel/Dockerfile.run -t notion-run $notion_root
 docker run --rm -it --name notion-test -v /tmp/.X11-unix:/tmp/.X11-unix notion-run
 


### PR DESCRIPTION
Run make clean before running make just in case you sources were already
compiled.
The base scripts now references the Dockerfile.* using the absolute path,
this allows the scripts to be run from other directory, ie,if you're
in notion/ you can call ./utils/docker/docker-bash.sh without having to cd
into the directory.