### PR TITLE
Auto allocate bindmap [#276]

### DIFF
--- a/ioncore/bindmaps.c
+++ b/ioncore/bindmaps.c
@@ -173,6 +173,10 @@ EXTL_EXPORT
 bool ioncore_do_defbindings(const char *name, ExtlTab tab)
 {
     WBindmap *bm=ioncore_lookup_bindmap(name);
+
+    if(bm==NULL)
+        bm=ioncore_alloc_bindmap(name, NULL);
+
     if(bm==NULL){
         warn("Unknown bindmap %s.", name);
         return FALSE;


### PR DESCRIPTION
Started in #276 
This is a a very small change to the code base which only affects the lua exposed function.
As far as I can tell the auto-allocated bindmaps are also deallocated by ioncore.
Some modules also de-/allocate bindmaps, their usage is also unchanged.

I am not sure if more needs to be done here? Any thoughts?