### PR TITLE
Add default implementation for WRegion:current

### DIFF
--- a/ioncore/region.c
+++ b/ioncore/region.c
@@ -248,6 +248,10 @@ WRegion *region_current(WRegion *mgr)
     return ret;
 }
 
+WRegion *region_current_default(WRegion *reg)
+{
+    return reg->active_sub;
+}
 
 void region_child_removed(WRegion *reg, WRegion *sub)
 {
@@ -1023,6 +1027,9 @@ static DynFunTab region_dynfuntab[]={
 
     {region_updategr,
      region_updategr_default},
+
+    {(DynFun*)region_current,
+     (DynFun*)region_current_default},
 
     {(DynFun*)region_rescue_clientwins,
      (DynFun*)region_rescue_child_clientwins},

--- a/ioncore/rootwin.c
+++ b/ioncore/rootwin.c
@@ -434,7 +434,7 @@ static bool scr_ok(WRegion *r)
 
 
 /*EXTL_DOC
- * Returns previously active screen on root window \var{rootwin}.
+ * Returns the most recently active screen on root window \var{rootwin}.
  */
 EXTL_SAFE
 EXTL_EXPORT_MEMBER
@@ -495,7 +495,6 @@ static DynFunTab rootwin_dynfuntab[]={
     {region_do_set_focus, rootwin_do_set_focus},
     {(DynFun*)region_xwindow, (DynFun*)rootwin_x_window},
     {(DynFun*)region_fitrep, (DynFun*)rootwin_fitrep},
-    {(DynFun*)region_current, (DynFun*)rootwin_current_scr},
     {region_managed_remove, rootwin_managed_remove},
     {(DynFun*)region_managed_disposeroot,
      (DynFun*)rootwin_managed_disposeroot},


### PR DESCRIPTION
This will automatically implement it for WRootWin, where the active subwindow
will typically be a WScreen.

Follow-up on #275