### PR TITLE
Xinerama crashing bug on non-xinerama screens

### DIFF
--- a/mod_xrandr/mod_xrandr.c
+++ b/mod_xrandr/mod_xrandr.c
@@ -245,6 +245,10 @@ ExtlTab mod_xrandr_get_outputs_for_geom(ExtlTab geom)
     XRRScreenResources *res = XRRGetScreenResources(ioncore_g.dpy, ioncore_g.rootwins->dummy_win);
     ExtlTab result = extl_create_table();
 
+    if (!res) {
+      return result;
+    }
+	
     for(i=0; i < res->noutput; i++){
         int x,y;
         int w,h;


### PR DESCRIPTION
There's a possibility of a null pointer returned by
XRRGetScreenResources in mod_xrandr_get_outputs_for_geom. It wasn't
getting checked. Now it is.