### PR TITLE
scratchpad: default to size 800x600

### DIFF
--- a/mod_sp/main.h
+++ b/mod_sp/main.h
@@ -16,7 +16,7 @@ extern void mod_sp_deinit();
 
 extern WBindmap *mod_sp_scratchpad_bindmap;
 
-#define CF_SCRATCHPAD_DEFAULT_W 640
-#define CF_SCRATCHPAD_DEFAULT_H 480
+#define CF_SCRATCHPAD_DEFAULT_W 800
+#define CF_SCRATCHPAD_DEFAULT_H 600
 
 #endif /* ION_MOD_SP_MAIN_H */


### PR DESCRIPTION
This seems like a more appropriate size for displays in the current
decade. Even better would of course be to remove the compile-time
constant (ticket #320).