### PR TITLE
Fix compilation on OpenBSD

### DIFF
--- a/mod_notionflux/mod_notionflux.c
+++ b/mod_notionflux/mod_notionflux.c
@@ -36,7 +36,7 @@
 
 typedef struct{
     int fd;
-    FILE *stdout;
+    FILE *stdoutput;
     int ndata;
     char *data;
 } Buf;
@@ -64,9 +64,9 @@ static void close_conn(Buf *buf)
     close(buf->fd);
     buf->fd=-1;
     buf->ndata=0;
-    if(buf->stdout!=NULL){
-        fclose(buf->stdout);
-        buf->stdout=NULL;
+    if(buf->stdoutput!=NULL){
+        fclose(buf->stdoutput);
+        buf->stdoutput=NULL;
     }
     if(buf->data!=NULL){
         free(buf->data);
@@ -147,11 +147,11 @@ static void receive_data(int fd, void *buf_)
     bool success=FALSE;
     int idx=buf-bufs;
 
-    if(buf->stdout==NULL){ /* no fd received yet, must be the very beginning */
-        int stdout_fd=unix_recv_fd(fd);
-        if(stdout_fd==-2)
+    if(buf->stdoutput==NULL){ /* no fd received yet, must be the very beginning */
+        int stdoutput_fd=unix_recv_fd(fd);
+        if(stdoutput_fd==-2)
             goto closefd;
-        if(stdout_fd==-3){
+        if(stdoutput_fd==-3){
             char const *err="Magic number mismatch on notionflux socket - "
                 "is notionflux the same version as notion?";
             writes(fd, "E");
@@ -160,13 +160,13 @@ static void receive_data(int fd, void *buf_)
             goto closefd;
         }
 
-        if(stdout_fd==-1) {
+        if(stdoutput_fd==-1) {
             if(errno==EWOULDBLOCK || errno==EAGAIN)
                 return; /* try again later */
             warn("No file descriptor received from notionflux, closing.");
             goto closefd;
         }
-        if((buf->stdout=fdopen(stdout_fd, "w"))==NULL) {
+        if((buf->stdoutput=fdopen(stdoutput_fd, "w"))==NULL) {
             warn("fdopen() failed on fd from notionflux");
             goto closefd;
         }
@@ -239,9 +239,9 @@ EXTL_SAFE
 EXTL_EXPORT
 bool mod_notionflux_xwrite(int idx, const char *str)
 {
-    if (idx<0 || idx>=MAX_SERVED || bufs[idx].stdout==NULL)
+    if (idx<0 || idx>=MAX_SERVED || bufs[idx].stdoutput==NULL)
         return FALSE;
-    return fputs(str, bufs[idx].stdout)!=EOF;
+    return fputs(str, bufs[idx].stdoutput)!=EOF;
 }
 
 static void connection_attempt(int lfd, void *UNUSED(data))
@@ -410,7 +410,7 @@ bool mod_notionflux_init()
 
     for(i=0; i<MAX_SERVED; i++){
         bufs[i].fd=-1;
-        bufs[i].stdout=NULL;
+        bufs[i].stdoutput=NULL;
         bufs[i].data=NULL;
         bufs[i].ndata=0;
     }


### PR DESCRIPTION
Hello,
The variable name "stdout" is defined in stdio.h on OpenBSD already. In order to make mod_notionflux compile on this OS, it would be necessary to rename this variable.
