### PR TITLE
Find lua versions without dot

### DIFF
--- a/build/lua-detect.mk
+++ b/build/lua-detect.mk
@@ -31,7 +31,7 @@ lua_ver_extract = $(shell $1 -v 2>&1 | cut -f2 -d' ' | cut -f-2 -d.)
 PKG_CONFIG_ALL_PACKAGES:= $(shell pkg-config --list-all | cut -f1 -d' ')
 
 # these are in order of preference
-LUA_CANDIDATES:=		$(or $(LUA_VERSION),5.4 5.3 5.2 5.1)
+LUA_CANDIDATES:=		$(or $(LUA_VERSION),5.4 54 5.3 53 5.2 52 5.1 51)
 LUA_BIN_CANDIDATES:=		$(foreach ver,$(LUA_CANDIDATES),lua$(ver) lua-$(ver))
 LUAC_BIN_CANDIDATES:=		$(foreach ver,$(LUA_CANDIDATES),luac$(ver) luac-$(ver))
 


### PR DESCRIPTION
Hello,
OpenBSD names lua executables lua51, lua52 ...
I'm not sure if other systems are doing this as well. But it won't hurt to add those to the auto detection logic.