### PR TITLE
Propagate libtu includes/libraries

### DIFF
--- a/libtu/test/Makefile
+++ b/libtu/test/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/build/system-inc.mk
 
 SOURCES=../misc.c ../tokenizer.c ../util.c ../output.c
 
-LIBS += $(LUA_LIBS) $(DL_LIBS) -lm
+LIBS += $(LUA_LIBS) $(DL_LIBS) $(LIBTU_LIBS) -lm
 INCLUDES += $(LIBTU_INCLUDES)
 CFLAGS += $(XOPEN_SOURCE) $(C99_SOURCE)
 
@@ -17,6 +17,6 @@ include $(TOPDIR)/build/rules.mk
 ######################################
 
 test: $(SOURCES)
-	$(CC) $(CFLAGS) -o tutest $(SOURCES) tutest.c $(LIBS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o tutest $(SOURCES) tutest.c $(LIBS)
 	./tutest
 	$(RM) ./tutest

--- a/utils/ion-completefile/Makefile
+++ b/utils/ion-completefile/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/build/system-inc.mk
 
 LIBS += $(LIBTU_LIBS)
 INCLUDES += $(LIBTU_INCLUDES)
-CFLAGS += $(XOPEN_SOURCE)
+CFLAGS += $(XOPEN_SOURCE) $(INCLUDES)
 
 SOURCES=ion-completefile.c
 
@@ -23,7 +23,7 @@ include $(TOPDIR)/build/rules.mk
 ######################################
 
 ion-completefile: $(SOURCES)
-	$(CC) $< $(CFLAGS) $(LDFLAGS) -o $@
+	$(CC) $< $(CFLAGS) $(LDFLAGS) $(LIBS) -o $@
 
 _install:
 	$(INSTALLDIR) $(DESTDIR)$(EXTRABINDIR)


### PR DESCRIPTION
Hello,
I had to set custom LIBTU_LIBS and LIBTU_INCLUDES. Those were not properly propagated to the build of `tutest` and `ion-completionfile`. The PR fixes this.