### PR TITLE
Remove bash dependency

### DIFF
--- a/contrib/install-scripts.sh
+++ b/contrib/install-scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # by Dan Weiner <dbw@uchicago.edu>
 # Public Domain

--- a/utils/dev-search-dirs.sh
+++ b/utils/dev-search-dirs.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-this_rel=$(dirname ${BASH_SOURCE[0]})
+this_rel=$(dirname "$0")
 rel_root=$this_rel/..
 
 notion_root=$(realpath $rel_root)


### PR DESCRIPTION
Hello,
this PR removes the bash dependency to install notion. It also fixed an incompatibility, because bash is not always in `/bin/bash`. On BSDs it's usually under `/usr/local/bin`.

Besides that. There's nothing in these scripts that need the bash.

I didn't touch the docker scripts and also let `nextversion.sh` alone. I think those are maintainer tools.