### PR TITLE
Remove bash dependency

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/build/system-inc.mk
 
 ######################################
 
-SHELL=bash -o pipefail
+SHELL=sh -e
 
 TARGETS=notion.1 notionflux.1 welcome.txt
 


### PR DESCRIPTION
Hello,
this change removes the dependency on bash to build notion.

I don't think where -o pipefail would be of use in this script. I changed it to -e so it would brake in case an unhandled error would occur. It runs fine here without bash installed.