### PR TITLE
Remove handling for external libtu/libextl

### DIFF
--- a/build/libs.mk
+++ b/build/libs.mk
@@ -6,36 +6,14 @@ LIBMAINLOOP_LIBS = -L$(LIBMAINLOOP_DIR) -lmainloop
 
 CFLAGS += -DNOTION_RELEASE='"$(NOTION_RELEASE)"'
 
-ifeq ($(wildcard $(TOPDIR)/libtu/obj.h),)
-
-#External libtu, feel free to edit
-LIBTU_DIR = $(TOPDIR)/../libtu
-LIBTU_INCLUDES =
-LIBTU_LIBS = -ltu
-
-else
-
-#In-tree libtu
+# libtu
 LIBS_SUBDIRS += libtu
 
 LIBTU_DIR = $(TOPDIR)/libtu
 LIBTU_INCLUDES = -I$(TOPDIR)
 LIBTU_LIBS = -L$(LIBTU_DIR) -ltu
 
-endif
-
-ifeq ($(wildcard $(TOPDIR)/libextl/luaextl.h),)
-
-#External libextl, feel free to edit
-LIBEXTL_DIR = $(TOPDIR)/../libextl
-LIBEXTL_INCLUDES =
-LIBEXTL_LIBS = -lextl
-
-MKEXPORTS = libextl-mkexports
-
-else
-
-#In-tree libextl
+#libextl
 LIBS_SUBDIRS += libextl
 
 LIBEXTL_DIR = $(TOPDIR)/libextl
@@ -43,5 +21,3 @@ LIBEXTL_INCLUDES = -I$(TOPDIR)
 LIBEXTL_LIBS = -L$(LIBEXTL_DIR) -lextl
 
 MKEXPORTS = $(LUA) $(LIBEXTL_DIR)/libextl-mkexports
-
-endif


### PR DESCRIPTION
Hello,

libtu and libextl are bundled with notion. Is the handling of an external libtu/libextl still required? I don't think so, but YMMV.