### PR TITLE
Respect cflags

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -2,6 +2,9 @@
 ## Some make rules
 ##
 
+AR ?= ar
+ARFLAGS = cr
+
 ifdef MODULE
 ifeq ($(PRELOAD_MODULES),1)
 MODULE_TARGETS := $(MODULE).a $(MODULE).lc
@@ -108,7 +111,6 @@ LINKOPT=-shared
 
 $(MODULE).a: $(OBJS) $(EXT_OBJS)
 	$(AR) $(ARFLAGS) $@ $+
-	$(RANLIB) $@
 
 module_install: module_stub_install
 

--- a/build/rules.mk
+++ b/build/rules.mk
@@ -99,7 +99,7 @@ $(MODULE).so: $(OBJS) $(EXT_OBJS)
 
 module_install: module_stub_install
 	$(INSTALLDIR) $(DESTDIR)$(MODULEDIR)
-	$(INSTALL) -m $(BIN_MODE) $(MODULE).so $(DESTDIR)$(MODULEDIR)
+	$(INSTALL) $(INSTALL_STRIP) -m $(BIN_MODE) $(MODULE).so $(DESTDIR)$(MODULEDIR)
 
 else # PRELOAD_MODULES
 

--- a/ioncore/Makefile
+++ b/ioncore/Makefile
@@ -56,6 +56,5 @@ ioncore.o: exports.h
 
 ioncore.a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $+
-	$(RANLIB) $@
 
 _install: lc_install

--- a/libextl/Makefile
+++ b/libextl/Makefile
@@ -39,7 +39,6 @@ ifdef LUA
 
 libextl.a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $+
-	$(RANLIB) $@
 
 libextl-mkexports: libextl-mkexports.in
 	sed "1s:LUA50:$(LUA):" $< > $@

--- a/libextl/build/rules.mk
+++ b/libextl/build/rules.mk
@@ -92,7 +92,6 @@ LINKOPT=-shared
 
 $(MODULE).a: $(OBJS) $(EXT_OBJS)
 	$(AR) $(ARFLAGS) $@ $+
-	$(RANLIB) $@
 
 module_install: module_stub_install
 

--- a/libextl/build/rules.mk
+++ b/libextl/build/rules.mk
@@ -83,7 +83,7 @@ $(MODULE).so: $(OBJS) $(EXT_OBJS)
 
 module_install: module_stub_install
 	$(INSTALLDIR) $(MODULEDIR)
-	$(INSTALL) -m $(BIN_MODE) $(MODULE).so $(MODULEDIR)
+	$(INSTALL) $(INSTALL_STRIP) -m $(BIN_MODE) $(MODULE).so $(MODULEDIR)
 
 else # PRELOAD_MODULES
 

--- a/libextl/system-autodetect.mk
+++ b/libextl/system-autodetect.mk
@@ -126,14 +126,6 @@ LDFLAGS ?= -Wl,-O1 -Wl,--as-needed
 # might allow for those optimisations to be taken without any  special
 # libc or compiler options.
 
-##
-## AR
-##
-
-AR=ar
-ARFLAGS=cr
-RANLIB=ranlib
-
 
 ##
 ## Install & strip

--- a/libmainloop/Makefile
+++ b/libmainloop/Makefile
@@ -26,6 +26,5 @@ include $(TOPDIR)/build/rules.mk
 
 libmainloop.a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $+
-	$(RANLIB) $@
 
 _install:

--- a/libtu/Makefile
+++ b/libtu/Makefile
@@ -36,7 +36,6 @@ include $(TOPDIR)/build/rules.mk
 
 libtu.a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $+
-	$(RANLIB) $@
 
 install:
 	$(INSTALLDIR) $(DESTDIR)$(LIBDIR)

--- a/libtu/build/rules.mk
+++ b/libtu/build/rules.mk
@@ -87,7 +87,7 @@ $(MODULE).so: $(OBJS) $(EXT_OBJS)
 
 module_install: module_stub_install
 	$(INSTALLDIR) $(MODULEDIR)
-	$(INSTALL) -m $(BIN_MODE) $(MODULE).so $(MODULEDIR)
+	$(INSTALL) $(INSTALL_STRIP) -m $(BIN_MODE) $(MODULE).so $(MODULEDIR)
 
 else # PRELOAD_MODULES
 

--- a/libtu/build/rules.mk
+++ b/libtu/build/rules.mk
@@ -96,7 +96,6 @@ LINKOPT=-shared
 
 $(MODULE).a: $(OBJS) $(EXT_OBJS)
 	$(AR) $(ARFLAGS) $@ $+
-	$(RANLIB) $@
 
 module_install: module_stub_install
 

--- a/libtu/system-autodetect.mk
+++ b/libtu/system-autodetect.mk
@@ -53,15 +53,6 @@ LDFLAGS ?= -Wl,-O1 -Wl,--as-needed
 
 
 ##
-## AR
-##
-
-AR=ar
-ARFLAGS=cr
-RANLIB=ranlib
-
-
-##
 ## Install & strip
 ##
 

--- a/mod_notionflux/notionflux/Makefile
+++ b/mod_notionflux/notionflux/Makefile
@@ -32,4 +32,4 @@ notionflux: $(OBJS) $(EXT_OBJS)
 
 _install: notionflux
 	$(INSTALLDIR) $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m $(BIN_MODE) notionflux $(DESTDIR)$(BINDIR)
+	$(INSTALL) $(INSTALL_STRIP) -m $(BIN_MODE) notionflux $(DESTDIR)$(BINDIR)

--- a/mod_statusbar/ion-statusd/Makefile
+++ b/mod_statusbar/ion-statusd/Makefile
@@ -38,4 +38,4 @@ ion-statusd: $(OBJS) $(EXT_OBJS)
 
 _install: lc_install
 	$(INSTALLDIR) $(DESTDIR)$(EXTRABINDIR)
-	$(INSTALL) -s -m $(BIN_MODE) ion-statusd $(DESTDIR)$(EXTRABINDIR)
+	$(INSTALL) $(INSTALL_STRIP) -m $(BIN_MODE) ion-statusd $(DESTDIR)$(EXTRABINDIR)

--- a/notion/Makefile
+++ b/notion/Makefile
@@ -59,4 +59,4 @@ preload.c:
 
 _install:
 	$(INSTALLDIR) $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m $(BIN_MODE) notion $(DESTDIR)$(BINDIR)
+	$(INSTALL) $(INSTALL_STRIP) -m $(BIN_MODE) notion $(DESTDIR)$(BINDIR)

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -183,9 +183,10 @@ WARN=-W -Wall -pedantic
 # For increased debug info, pass DEBUG=1 to make
 #
 ifeq ($(DEBUG),1)
-    CFLAGS+= -ggdb3 -O0
+    CFLAGS ?= -O0
+    CFLAGS += -ggdb3
 else
-    CFLAGS+= -g -Os
+    CFLAGS ?= -g -Os
 endif
 CFLAGS += $(WARN) $(DEFINES) $(INCLUDES) $(EXTRA_INCLUDES) \
           -DHAS_SYSTEM_ASPRINTF=$(HAS_SYSTEM_ASPRINTF)

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -232,7 +232,7 @@ RANLIB ?= ranlib
 ##
 
 INSTALL ?= sh $(TOPDIR)/install-sh -c
-INSTALL_STRIP = -s
+INSTALL_STRIP ?= -s
 INSTALLDIR ?= mkdir -p
 
 BIN_MODE ?= 755

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -211,14 +211,6 @@ C99_SOURCE?=-std=c99 -DCF_HAS_VA_COPY
 # might allow for those optimisations to be taken without any  special
 # libc or compiler options.
 
-##
-## AR
-##
-
-AR ?= ar
-ARFLAGS ?= cr
-RANLIB ?= ranlib
-
 
 ##
 ## Install & strip

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -175,8 +175,6 @@ EXTRA_LIBS += -lrt
 ## C compiler.
 ##
 
-CC ?= gcc
-
 WARN=-W -Wall -pedantic
 
 #

--- a/system-autodetect.mk
+++ b/system-autodetect.mk
@@ -74,11 +74,6 @@ include $(TOPDIR)/build/lua-detect.mk
 ## X libraries, includes and options
 ##
 
-# Paths
-X11_PREFIX ?= /usr/X11R6
-# SunOS/Solaris
-#X11_PREFIX ?= /usr/openwin
-
 X11_LIBS:=$(shell $(PKG_CONFIG) --libs x11 xext)
 X11_INCLUDES:=$(shell $(PKG_CONFIG) --cflags-only-I x11 xext)
 

--- a/utils/ion-completefile/Makefile
+++ b/utils/ion-completefile/Makefile
@@ -27,4 +27,4 @@ ion-completefile: $(SOURCES)
 
 _install:
 	$(INSTALLDIR) $(DESTDIR)$(EXTRABINDIR)
-	$(INSTALL) -s -m $(BIN_MODE) ion-completefile $(DESTDIR)$(EXTRABINDIR)
+	$(INSTALL) $(INSTALL_STRIP) -m $(BIN_MODE) ion-completefile $(DESTDIR)$(EXTRABINDIR)


### PR DESCRIPTION
@raboof the second part of our patches. Most of these should simplify the build system and allow us to override all variables.

I've put the rationale for removing `RANLIB` into the commit message: `ranlib` is also necessary when re-indexing static archives after stripping them.