### PR TITLE
Invoke `ar -s` for non-GNU/SysV toolchains

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -3,7 +3,7 @@
 ##
 
 AR ?= ar
-ARFLAGS = cr
+ARFLAGS = rcs
 
 ifdef MODULE
 ifeq ($(PRELOAD_MODULES),1)


### PR DESCRIPTION
@raboof some older BSD toolchains require `-s`, so this should fix it on those OSes too.