### PR TITLE
Parallel build fixes

### DIFF
--- a/mod_mgmtmode/Makefile
+++ b/mod_mgmtmode/Makefile
@@ -24,3 +24,7 @@ include $(TOPDIR)/build/rules.mk
 ######################################
 
 _install: module_install
+
+######################################
+
+main.o: exports.h

--- a/mod_notionflux/Makefile
+++ b/mod_notionflux/Makefile
@@ -29,3 +29,7 @@ include $(TOPDIR)/build/rules.mk
 ######################################
 
 _install: module_install
+
+######################################
+
+mod_notionflux.o: exports.h


### PR DESCRIPTION
Two small fixes for missing generated headers:

      mod_mgmtmode: add main.o depend on exports.h
      mod_notionflux: add mod_notionflux.o depend on exports.h

Both fixes are derived from build failures found by `make --shuffle`
added upcoming GNU `make-4.4`.

Before the change `notion` build failed after 2-3 build attempts on missing
`exports.h` if any of two fixes above is not applied.
After the change `notion` survived 15 rebuilds.