### PR TITLE
Rescue the client window group instead of the client window on unsplitting

### DIFF
--- a/ioncore/manage.c
+++ b/ioncore/manage.c
@@ -370,7 +370,16 @@ bool region_rescue_some_clientwins(WRegion *reg, WRescueInfo *info,
                     break;
                 }
             }
-            if(!pholder_attach(info->ph, 0, (WRegion*)cwin))
+
+            WRegion *movereg = (WRegion*)cwin;
+
+            /* If the client window is managed by a GroupCW, move the GroupCW instead. */
+            WGroupCW *cwg = REGION_MANAGER_CHK(movereg, WGroupCW);
+            if(cwg!=NULL){
+                movereg = (WRegion*)cwg;
+            }
+
+            if(!pholder_attach(info->ph, 0, movereg))
                 fails++;
         }
     }

--- a/ioncore/pholder.c
+++ b/ioncore/pholder.c
@@ -190,15 +190,15 @@ WPHolder *region_managed_get_pholder(WRegion *reg, WRegion *mgd)
 
 WPHolder *region_get_rescue_pholder_for(WRegion *reg, WRegion *mgd)
 {
-    if(OBJ_IS_BEING_DESTROYED(reg) || reg->flags&REGION_CWINS_BEING_RESCUED){
-        return FALSE;
-    }else{
-        WPHolder *ret=NULL;
+    WPHolder *ret=NULL;
 
-        CALL_DYN_RET(ret, WPHolder*, region_get_rescue_pholder_for,
-                     reg, (reg, mgd));
+    if(OBJ_IS_BEING_DESTROYED(reg) || reg->flags&REGION_CWINS_BEING_RESCUED){
         return ret;
     }
+
+    CALL_DYN_RET(ret, WPHolder*, region_get_rescue_pholder_for,
+                 reg, (reg, mgd));
+    return ret;
 }
 
 

--- a/mod_tiling/tiling.c
+++ b/mod_tiling/tiling.c
@@ -1072,7 +1072,7 @@ void do_unsplit(WRegion *reg)
         return;
     }
 
-    destroy_obj((Obj*)reg);
+    mainloop_defer_destroy((Obj*)reg);
 }
 
 


### PR DESCRIPTION
Rescue the client window group instead of the client window on unsplitting.
Also small stuff I stumbled upon.

Someone who knows what they are doing should review this. It might fail spectacularly in some cases.
I have no clue why every client window is managed by a client window group.

Generating a graph of the objects and managing relation helped debugging the issue:
```
echo "digraph managing {$(notionflux << EOF | grep -v '^nil$'

function label(sub)
    return tostring(sub) .. (sub:name() and " (" .. sub:name() .. ")" or "");
end

function dump(sub)
    print("\"" .. label(sub:manager()) .. "\" -> \"" .. label(sub) .. "\";");
    return true;
end

notioncore.clientwin_i(dump)
notioncore.region_i(dump)

EOF
)}" | dot -Tpng -o /tmp/graph.png
```

fixes #316