### PR TITLE
Fix build with GCC 14 and above

### DIFF
--- a/ioncore/frame.c
+++ b/ioncore/frame.c
@@ -796,7 +796,7 @@ bool frame_set_numbers_extl(WFrame *frame, const char *how)
 {
     if(how!=NULL && strcmp(how, "during_grab")==0){
         bool new_state = frame_set_numbers(frame, SETPARAM_SET);
-        ioncore_grab_establish(frame, numbers_grab_handler, NULL,
+        ioncore_grab_establish((WRegion *)frame, numbers_grab_handler, NULL,
                                0, GRAB_DEFAULT_FLAGS&~GRAB_POINTER);
         return new_state;
     }


### PR DESCRIPTION
Newer compilers such as GCC 14 ( and above ) have enabled a few compiler flags by default, -Wincompatible-pointer-types being one of them. Thus resulting in build errors such as:

frame.c: In function ‘frame_set_numbers_extl’:
frame.c:799:32: error: passing argument 1 of ‘ioncore_grab_establish’ from incompatible pointer type [-Wincompatible-pointer-types]
  799 |         ioncore_grab_establish(frame, numbers_grab_handler, NULL,
      |                                ^~~~~
      |                                |
      |                                WFrame * {aka struct WFrame_struct *}

For now a type casting can be used to supress the error, as change the type of frame would require touching other parts of the codebase.

First reported on Gentoo Linux with GCC 14, for more details please reffer https://bugs.gentoo.org/919249