### PR TITLE
Fix libextl test invocation

### DIFF
--- a/libextl/test/Makefile
+++ b/libextl/test/Makefile
@@ -23,8 +23,9 @@ include $(TOPDIR)/build/rules.mk
 
 ######################################
 
+.PHONY: test
 test: $(SOURCES)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(SOURCES) extltest.c $(INCLUDES) -o $@ $(LIBS)
-	./extltest
-	# $(RM) extltest
+	./$@
+	# $(RM) $@
 


### PR DESCRIPTION
based on https://salsa.debian.org/debian/notion/-/commit/f0a26aa75689492b39c575664a1d333f00cca5e3