### PR TITLE
Changes goto_previous to accept an integer number of which previous

### DIFF
--- a/ioncore/focus.c
+++ b/ioncore/focus.c
@@ -81,7 +81,7 @@ static void region_focuslist_deinit(WRegion *reg)
  * actually have received the focus when this function returns.
  */
 EXTL_EXPORT
-WRegion *ioncore_goto_previous()
+WRegion *ioncore_goto_previous(int count)
 {
     WRegion *next;
 
@@ -99,7 +99,7 @@ WRegion *ioncore_goto_previous()
         next!=NULL;
         next=next->active_next){
 
-        if(!REGION_IS_ACTIVE(next))
+        if(!REGION_IS_ACTIVE(next) && --count <= 0)
             break;
     }
 

--- a/ioncore/focus.h
+++ b/ioncore/focus.h
@@ -52,7 +52,7 @@ extern void region_focuslist_move_after(WRegion *reg, WRegion *after);
 /* Notify the focus handling that the region is deinit'ing */
 extern void region_focus_deinit(WRegion *reg);
 
-extern WRegion *ioncore_goto_previous();
+extern WRegion *ioncore_goto_previous(int count);
 
 /* Handlers to this hook should take WRegion* as parameter. */
 extern WHook *region_do_warp_alt;


### PR DESCRIPTION
This addresses a long outstanding issue I've had ... I often want things like a basic alt+tab without a lot of cognitive load. goto_previous was fine if the desire is 2, but oftentimes it's 3 and the problem is then we're either managing window placement, doing directional cycle, which takes mental bookkeeping or doing the focus-list cycle which takes 1 keystroke to bring it up, then another to cycle through, another to select it. These are all very inconvenient.

So this is a patch to make goto_previous accept a number. If it's 1, then it works as before. If it's 2 then it cycles between 3 windows. If it's 3, then it cycles between the previous 4 and so on. 

It is a *breaking change* and I'll be proposing another PR that has a more complicated notion of both directionality and offset which will have a new function signature and not be breaking.

Feel free to accept this, the other, or neither.