### PR TITLE
implements the ioncore-goto-hop alternative

### DIFF
--- a/ioncore/focus.h
+++ b/ioncore/focus.h
@@ -53,6 +53,7 @@ extern void region_focuslist_move_after(WRegion *reg, WRegion *after);
 extern void region_focus_deinit(WRegion *reg);
 
 extern WRegion *ioncore_goto_previous();
+extern WRegion *ioncore_goto_hop(int count, int direction);
 
 /* Handlers to this hook should take WRegion* as parameter. */
 extern WHook *region_do_warp_alt;


### PR DESCRIPTION
Here's the alternative as promised. It introduces a "goto-hop" which does not break anything but introduces a new function that can go both ways

I couldn't figure out a pure lua way to do this.