### PR TITLE
Reduce logspam on Xft-based systems. Fixes #382 and #383

### DIFF
--- a/de/font.c
+++ b/de/font.c
@@ -30,7 +30,7 @@ static DEFont *fonts=NULL;
 const char *de_default_fontname()
 {
 #ifdef HAVE_X11_XFT
-        return "xft:sans-serif:size=12";
+    return "xft:sans-serif:size=12";
 #else
     if(ioncore_g.use_mb)
         return "-*-helvetica-medium-r-normal-*-12-*-*-*-*-*-*-*";

--- a/de/font.c
+++ b/de/font.c
@@ -29,10 +29,14 @@ static DEFont *fonts=NULL;
 
 const char *de_default_fontname()
 {
+#ifdef HAVE_X11_XFT
+        return "xft:sans-serif:size=12";
+#else
     if(ioncore_g.use_mb)
         return "-*-helvetica-medium-r-normal-*-12-*-*-*-*-*-*-*";
     else
         return "fixed";
+#endif
 }
 
 DEFont *de_load_font(const char *fontname)

--- a/de/font.c
+++ b/de/font.c
@@ -84,7 +84,9 @@ DEFont *de_load_font(const char *fontname)
         }
         return NULL;
     }else{
-        FcPatternPrint(font->pattern);
+        /* FcPatternPrint(font->pattern); */
+        /* If you're thinking of commenting the above in, have a look at the
+        FC_DEBUG environment variable supported by Fontconfig. */
     }
 #endif /* HAVE_X11_XFT */
 


### PR DESCRIPTION
A better fallback font than helvetica for Xft-systems ("xft:sans-serif:size=12"). Gets rid of log message about missing charsets.
Comment out call of FcPatternPrint() only useful for debugging. Added a note regarding FC_DEBUG variable so that potential future devs looking at this code know about how to get this information (and more) back.

Fixes issues #382 and #383